### PR TITLE
Feature/ldapr related additions

### DIFF
--- a/lib/hawk/http/caching.rb
+++ b/lib/hawk/http/caching.rb
@@ -94,6 +94,8 @@ module Hawk
         end
 
         def initialize_cache(options)
+          return if options[:disabled]
+
           unless options.key?(:server)
             raise Error::Configuration, "Cache server option is mandatory"
           end

--- a/lib/hawk/http/instrumentation.rb
+++ b/lib/hawk/http/instrumentation.rb
@@ -33,7 +33,7 @@ module Hawk
               url << '?' << payload[:params].inject('') {|s, (k,v)| s << [k, '=', v, '&'].join }.chomp('&')
             end
 
-            $stderr.printf ">> \033[1mHawk #{type}: #{payload[:method]} #{url} (%.2fms), cache %s\033[0m\n" % [
+            $stderr.printf ">> \033[1mHawk #{type}: #{payload[:method]} #{CGI::unescape(url)} (%.2fms), cache %s\033[0m\n" % [
               elapsed,
               payload[:cached] ? 'HIT' : 'MISS'
             ]

--- a/lib/hawk/http/instrumentation.rb
+++ b/lib/hawk/http/instrumentation.rb
@@ -33,7 +33,8 @@ module Hawk
               url << '?' << payload[:params].inject('') {|s, (k,v)| s << [k, '=', v, '&'].join }.chomp('&')
             end
 
-            $stderr.printf ">> \033[1mHawk #{type}: #{payload[:method]} #{CGI::unescape(url)} (%.2fms), cache %s\033[0m\n" % [
+            $stderr.printf ">> \033[1mHawk #{type}: #{payload[:method]} %s (%.2fms), cache %s\033[0m\n" % [
+              CGI::unescape(url),
               elapsed,
               payload[:cached] ? 'HIT' : 'MISS'
             ]


### PR DESCRIPTION
While working on ldapr I got into adding:

- an option to disable the cache
- unescaping a url before printing it out avoids a malformed print string error