### PR TITLE
Add find_by as an alias of first

### DIFF
--- a/lib/hawk/model/proxy.rb
+++ b/lib/hawk/model/proxy.rb
@@ -44,6 +44,7 @@ module Hawk
       def first(params = {})
         limit(1).all(params).first
       end
+      alias find_by first
 
       def first!(params = {})
         first(params) or raise Hawk::Error::NotFound, "Can't find #{klass} with #{params.to_json}"

--- a/lib/hawk/model/querying.rb
+++ b/lib/hawk/model/querying.rb
@@ -72,6 +72,7 @@ module Hawk
         def first(params = {})
           limit(1).first(params)
         end
+        alias find_by first
 
         # Looks for the first record or raises a
         # {Hawk::Error::NotFound} if not found

--- a/spec/basic_operations_spec.rb
+++ b/spec/basic_operations_spec.rb
@@ -44,6 +44,12 @@ describe 'basic operations with a class that inherits from Hawk::Model::Base' do
     end
   end
 
+  describe '.find_by' do
+    it 'is an alias of first' do
+      expect(Person.method(:find_by).original_name).to eq(:first)
+    end
+  end
+
   describe '.all' do
     specify do
       stub_request(:GET, "http://zombo.com/people").


### PR DESCRIPTION
Allows to use find_by like other ActiveRecord models

@vjt `find_each` would also be a good addition: https://api.rubyonrails.org/v6.1.0/classes/ActiveRecord/Batches.html#method-i-find_each