### PR TITLE
Add Pagy support

### DIFF
--- a/lib/hawk/model/finder.rb
+++ b/lib/hawk/model/finder.rb
@@ -40,6 +40,7 @@ module Hawk
         end
 
         def count(params = {})
+          params = {} unless params.is_a?(Hash)
           path = path_for(count_path, params)
           method = connection.url_length(path,:get,params) > 2000 ? :post : :get
           repr = connection.send(method, path, params)

--- a/spec/collections_spec.rb
+++ b/spec/collections_spec.rb
@@ -52,12 +52,20 @@ describe 'collections and pagination' do
   end
 
   describe '.count' do
-    specify do
+    before do
       stub_request(:GET, "http://zombo.com/mosquitos/count").
         with(:headers => {'User-Agent'=>'Foobar'}).
         to_return(:status => 200, :body => {count: 123}.to_json, :headers => {})
+    end
 
+    specify do
       expect(Mosquito.count).to eq(123)
+    end
+
+    context 'when parameter is not a hash' do
+      specify do
+        expect { Mosquito.count(:all) }.not_to raise_error
+      end
     end
   end
 end


### PR DESCRIPTION
Pagy calls `count` on collections with `:all` as parameter.

This changes ensures that non hash parameters will be discarded