### PR TITLE
Chore/coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /tmp/
 Gemfile.lock
 gemfiles/*.gemfile.lock
+gemfiles/.bundle

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,11 @@
-if ENV['RCOV']
+if ENV['RCOV'] || ENV['COVERAGE']
   require 'simplecov'
-  SimpleCov.start
+
+  SimpleCov.start do
+    add_filter '/spec/'
+
+    track_files 'lib/**/*.rb'
+  end
 end
 
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)


### PR DESCRIPTION
- Ignore .bundle folder under gemfiles
- Only include /lib in coverage reports