### PR TITLE
Require CGI in HTTP Instrumentation module

### DIFF
--- a/lib/hawk/http/instrumentation.rb
+++ b/lib/hawk/http/instrumentation.rb
@@ -1,3 +1,5 @@
+require 'cgi'
+
 module Hawk
   class HTTP
     module Instrumentation


### PR DESCRIPTION
HTTP Instrumentation module uses CGI to escape URL. This will prevent issues when using Hawk and CGI has not been already loaded by third-party dependencies

E.g.:
```
$ bin/console
> Hawk::HTTP.new('http://example.com/').get('/')
NameError (uninitialized constant Hawk::HTTP::Instrumentation::Basic::CGI)
```