### PR TITLE
Improve pagination

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -101,10 +101,6 @@ Rails/TimeZone:
   Exclude:
     - 'lib/hawk/model/schema.rb'
 
-Security/Eval:
-  Exclude:
-    - 'lib/hawk/model/pagination.rb'
-
 Style/ClassVars:
   Exclude:
     - 'lib/hawk/http/caching.rb'
@@ -119,7 +115,6 @@ Style/DocumentDynamicEvalDefinition:
   Exclude:
     - 'lib/hawk/linker.rb'
     - 'lib/hawk/model/association.rb'
-    - 'lib/hawk/model/pagination.rb'
 
 # Configuration parameters: AllowedConstants.
 Style/Documentation:

--- a/lib/hawk/model/pagination.rb
+++ b/lib/hawk/model/pagination.rb
@@ -5,7 +5,11 @@ module Hawk
     module Pagination
       module Common
         def current_page
-          limit_value == 0 ? 1 : (offset_value / limit_value) + 1
+          if limit_value == 0
+            1
+          else
+            (offset_value / limit_value) + 1
+          end
         end
       end
 
@@ -14,12 +18,9 @@ module Hawk
           base.instance_eval do
             include Kaminari::ConfigurationMethods
 
-            eval <<-RUBY, binding, __FILE__, __LINE__ + 1
-              def #{Kaminari.config.page_method_name}(num = nil)
-                limit(default_per_page).
-                offset(default_per_page * ([num.to_i, 1].max - 1))
-              end
-            RUBY
+            define_singleton_method Kaminari.config.page_method_name do |num = nil|
+              limit(default_per_page).offset(default_per_page * ([num.to_i, 1].max - 1))
+            end
           end
         end
 


### PR DESCRIPTION
- Do not use ternary operator to improve coverage
- Define a singleton method instead of using eval