### PR TITLE
Remove AM < 6.1 legacy conditional check

### DIFF
--- a/lib/hawk/linker.rb
+++ b/lib/hawk/linker.rb
@@ -37,7 +37,7 @@ module Hawk
           def #{entity}
             return nil unless self.#{key}.present?
 
-            @_#{entity} ||= #{respond_to?(:module_parent) ? module_parent : parent}::#{klass}.find(self.#{key})
+            @_#{entity} ||= #{module_parent}::#{klass}.find(self.#{key})
           end
         RUBY
 

--- a/lib/hawk/model/lookup.rb
+++ b/lib/hawk/model/lookup.rb
@@ -66,7 +66,7 @@ module Hawk
             return self_constant
           end
 
-          scope_parent = scope.respond_to?(:module_parent) ? scope.module_parent : scope.parent
+          scope_parent = scope.module_parent
 
           if (parent_constant = look_up_constant_in(name, scope_parent))
             return parent_constant
@@ -82,11 +82,7 @@ module Hawk
         end
 
         def look_up_constant_in(name, scope)
-          if scope.respond_to?(:module_parent)
-            scope.module_parent.const_get(name)
-          else
-            scope.parent.const_get(name)
-          end
+          scope.module_parent.const_get(name)
         rescue NameError
           nil
         end


### PR DESCRIPTION
`parent` was needed to support Active Model < 6.1.

Since the minimum required version is now 7.0, the conditional is not
needed anymore

Ref: rails/rails#34051

Close #12
