### PR TITLE
Squeeze multiple slashes in URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.byebug_history
 /.bundle/
 /.yardoc
 /coverage/

--- a/lib/hawk/http.rb
+++ b/lib/hawk/http.rb
@@ -116,7 +116,7 @@ module Hawk
     private
 
     def build_url(path)
-      base.merge(path.sub(%r{^/}, '')).to_s
+      base.merge(path.delete_prefix('/').squeeze('/')).to_s
     end
 
     def response_handler(response)

--- a/lib/hawk/version.rb
+++ b/lib/hawk/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Hawk
-  VERSION = '2.0.0'
+  VERSION = '3.0.0'
 end

--- a/spec/basic_operations_spec.rb
+++ b/spec/basic_operations_spec.rb
@@ -22,6 +22,16 @@ RSpec.describe 'basic operations with a class that inherits from Hawk::Model::Ba
     }
   end
 
+  describe '.get' do
+    it 'squeezes multiple slashes' do
+      stub_request(:GET, 'https://example.org/people/batch/id')
+        .with(headers: { 'User-Agent' => 'Foobar' })
+        .to_return(status: 200, body: [2].to_json, headers: {})
+
+      expect(Person.get('/batch///id')).to contain_exactly(2)
+    end
+  end
+
   describe '.find(id)' do
     specify do
       stub_request(:GET, 'https://example.org/people/2')


### PR DESCRIPTION
Ruby 2.5 has removed the normalization of multiple slashes in URLs, so you can get 301 redirect errors if you run for example `Model.get('/batch/id')`.

```
2.4 > URI.parse("http://example.org").merge('people//batch///id')
 => #<URI::HTTP http://example.org/people/batch/id> 
                                         ^     ^
```

```
2.5 > URI.parse("http://example.org").merge('people//batch///id')
 => #<URI::HTTP http://example.org/people//batch///id> 
                                         ^^     ^^^
```

In Hawk's use case, it should be safe to assume that paths should be squeezed, but since this can be considered a breaking change, this commit also bumps the major version number

Ref: https://bugs.ruby-lang.org/issues/8352