### PR TITLE
Do not test Rails 7.0 against Ruby 3.4 dev

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -34,9 +34,6 @@ jobs:
             channel: experimental
 
           - ruby-version: 'head'
-            gemfile: am_7.0
-            channel: experimental
-          - ruby-version: 'head'
             gemfile: am_7.1
             channel: experimental
           - ruby-version: 'head'


### PR DESCRIPTION
Stop testing Rails 7.0 against ruby-head, as 7.0 will now only receive security fixes.

Compatibility with future Ruby versions will be managed in newer Rails versions.

Ref: rails/rails#50546