### PR TITLE
Prefer `require_relative` for internal requires

### DIFF
--- a/lib/hawk.rb
+++ b/lib/hawk.rb
@@ -4,8 +4,8 @@ require 'active_support/core_ext/array/wrap'
 require 'active_support/core_ext/hash/deep_merge'
 require 'active_support/core_ext/object/blank'
 
-require 'hawk/version'
+require_relative 'hawk/version'
 
-require 'hawk/error'
-require 'hawk/http'
-require 'hawk/model'
+require_relative 'hawk/error'
+require_relative 'hawk/http'
+require_relative 'hawk/model'

--- a/lib/hawk/http.rb
+++ b/lib/hawk/http.rb
@@ -5,8 +5,8 @@ module Hawk
   require 'typhoeus'
   require 'multi_json'
 
-  require 'hawk/http/caching'
-  require 'hawk/http/instrumentation'
+  require_relative 'http/caching'
+  require_relative 'http/instrumentation'
 
   ##
   # Represent an HTTP connector, to be linked to a {Model}.


### PR DESCRIPTION
`require_relative` is preferred over `require` for files within the same project because it uses paths relative to the current file, making code more portable and less dependent on the load path.

This change updates internal requires to use `require_relative` for consistency, performance, and improved portability.

Ref:
- rubocop/rubocop#8748