### PR TITLE
Fix Style/HashFetchChain offense

### DIFF
--- a/lib/hawk/model/finder.rb
+++ b/lib/hawk/model/finder.rb
@@ -110,7 +110,7 @@ module Hawk
         end
 
         def model_path_from(params)
-          if (from = params.fetch(:options, {}).fetch(:endpoint, nil))
+          if (from = params.dig(:options, :endpoint))
             from = [model_path, from].join('/') unless from[0] == '/'
             from
           else

--- a/spec/basic_operations_spec.rb
+++ b/spec/basic_operations_spec.rb
@@ -91,6 +91,17 @@ RSpec.describe 'basic operations with a class that inherits from Hawk::Model::Ba
       collection = Person.all
       expect(collection.size).to eq(2)
     end
+
+    context 'with a custom endpoint' do
+      specify do
+        stub_request(:GET, 'https://example.org/people/active')
+          .with(headers: { 'User-Agent' => 'Foobar' })
+          .to_return(status: 200, body: [person_attributes, person_attributes].to_json, headers: {})
+
+        collection = Person.all(options: { endpoint: 'active' })
+        expect(collection.size).to eq(2)
+      end
+    end
   end
 
   describe '.where' do


### PR DESCRIPTION
This cop is marked as unsafe, but for this specific use case, the offense should be safe to autofix

```
Comparison (IPS):
                 dig: 11134481.1 i/s
         fetch_chain:  6504560.8 i/s - 1.71x  (± 0.00) slower

Comparison (Memory):
                 dig:          0 allocated
         fetch_chain:        160 allocated - Infx more
```