### PR TITLE
Fix Style/ItAssignment cop

### DIFF
--- a/lib/hawk/http.rb
+++ b/lib/hawk/http.rb
@@ -125,7 +125,7 @@ module Hawk
       req  = response.request
       url  = req.url
       meth = req.options.fetch(:method).to_s.upcase
-      it   = [meth, url].join(' ')
+      req_info = "#{meth} #{url}"
 
       if response.timed_out?
         what, secs = if response.connect_time&.zero?
@@ -135,24 +135,24 @@ module Hawk
                        [:request, req.options[:timeout]]
                      end
 
-        raise Error::Timeout, "#{it}: #{what} timed out after #{secs} seconds"
+        raise Error::Timeout, "#{req_info}: #{what} timed out after #{secs} seconds"
       end
 
       case (code = response.response_code)
       when 0
-        raise Error::Empty, "#{it}: Empty response from server (#{response.status_message})"
+        raise Error::Empty, "#{req_info}: Empty response from server (#{response.status_message})"
       when 400
-        raise Error::BadRequest, "#{it} was a bad request"
+        raise Error::BadRequest, "#{req_info} was a bad request"
       when 403
-        raise Error::Forbidden, "#{it} denied access"
+        raise Error::Forbidden, "#{req_info} denied access"
       when 404
-        raise Error::NotFound, "#{it} was not found"
+        raise Error::NotFound, "#{req_info} was not found"
       when 500
-        raise Error::InternalServerError, "#{it}: Server error (#{response.body[0..120]})"
+        raise Error::InternalServerError, "#{req_info}: Server error (#{response.body[0..120]})"
       else
         app_error = parse_app_error_from(response.body)
 
-        raise Error::HTTP.new(code, "#{it} failed with error #{code} (#{response.status_message}): #{app_error}")
+        raise Error::HTTP.new(code, "#{req_info} failed with error #{code} (#{response.status_message}): #{app_error}")
       end
     end
 


### PR DESCRIPTION
The `response_handler` method in `lib/hawk/http.rb` previously used the variable name `it` to store request information for error messages.

Ruby 3.4 introduces a new special variable `it` for single-line blocks. Using `it` as a local variable can now cause confusion or unexpected behavior, especially as Ruby evolves. The new RuboCop Style/ItAssignment cop enforces this best practice.

This commit renames the local variable `it` for clarity and future compatibility. No functional changes.

Additionally, use interpolation instead of array join for performance

```
Comparison (IPS):
       interpolation:  6610794.3 i/s
                join:  6103137.6 i/s - 1.08x  (± 0.00) slower

Comparison (Memory):
       interpolation:         80 allocated
                join:        120 allocated - 1.50x more
```

See: https://www.ruby-lang.org/en/news/2024/12/25/ruby-3-4-0-released/