### PR TITLE
Use cgi/escape instead of full cgi library

### DIFF
--- a/lib/hawk/http/instrumentation.rb
+++ b/lib/hawk/http/instrumentation.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'cgi'
+require 'cgi/escape'
 
 module Hawk
   class HTTP


### PR DESCRIPTION
Ruby 4.0 removed the bundled CGI gem, causing a warning when `require 'cgi'` is used. The cgi/escape module has been available since Ruby 2.0 and provides only CGI.escape and CGI.unescape, which is all this file needs.