### PR TITLE
Add YARD documentation and fill README Usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,26 +11,213 @@ clients. It consumes JSON and produces Ruby objects without any Hash magic.
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'hawk'
+gem 'hawk', github: 'ifad/hawk'
 ```
 
 And then execute:
 
-    $ bundle
-
-Or install it yourself as:
-
-    $ gem install hawk
+```sh
+$ bundle install
+```
 
 ## Usage
 
-TODO
+### Defining a Model
+
+Create a model class that inherits from `Hawk::Model::Base`:
+
+```ruby
+class Post < Hawk::Model::Base
+  url 'https://api.example.com/'
+  client_name 'MyApp/1.0'
+
+  schema do
+    integer :id
+    string :title, :body
+    datetime :created_at
+    boolean :published
+  end
+end
+```
+
+### Finding Records
+
+```ruby
+# Find by ID
+post = Post.find(1)
+post.title # => "Hello World"
+
+# Find multiple records
+posts = Post.find([1, 2, 3])
+
+# Get all records
+posts = Post.all
+
+# Get first record
+post = Post.first
+post = Post.first! # Raises Hawk::Error::NotFound if not found
+```
+
+### Querying
+
+```ruby
+# Filter with where
+posts = Post.where(published: true)
+
+# Chain queries
+posts = Post.where(published: true).order(:created_at).limit(10)
+
+# Use offsets
+posts = Post.offset(20).limit(10)
+
+# Custom endpoints
+posts = Post.from('featured')
+```
+
+### Defining Scopes
+
+```ruby
+class Post < Hawk::Model::Base
+  # ... schema ...
+
+  scope :published, -> { where(published: true) }
+  scope :recent, -> { order(:created_at).limit(10) }
+  scope :by_author, ->(name) { where(author: name) }
+end
+
+# Use scopes
+Post.published.all
+Post.recent.by_author('John').limit(5)
+```
+
+### Associations
+
+```ruby
+class Farm < Hawk::Model::Base
+  url 'https://api.example.com/'
+  client_name 'MyApp/1.0'
+
+  schema do
+    integer :id
+    string :name
+  end
+
+  has_many :animals
+end
+
+class Animal < Hawk::Model::Base
+  url 'https://api.example.com/'
+  client_name 'MyApp/1.0'
+
+  schema do
+    integer :id, :farm_id
+    string :name
+  end
+
+  belongs_to :farm
+  has_one :favourite_food, class_name: 'Food'
+end
+
+class Food < Hawk::Model::Base
+  url 'https://api.example.com/'
+  client_name 'MyApp/1.0'
+
+  schema do
+    integer :id
+    string :name
+  end
+end
+
+# Usage
+farm = Farm.find(1)
+farm.animals.all # => Collection of Animal records
+
+animal = Animal.find(1)
+animal.farm # => Farm record
+animal.favourite_food # => Food record
+```
+
+### Polymorphic Associations
+
+```ruby
+class Image < Hawk::Model::Base
+  url 'https://api.example.com/'
+  client_name 'MyApp/1.0'
+
+  schema do
+    integer :id, :imageable_id
+    string :url, :imageable_type
+  end
+
+  belongs_to :imageable, polymorphic: true
+end
+
+# Usage
+image = Image.find(1)
+image.imageable # => Returns the associated record (Animal, Post, etc.)
+```
+
+### Caching
+
+Hawk supports Memcached-based caching for GET requests:
+
+```ruby
+class Post < Hawk::Model::Base
+  url 'https://api.example.com/'
+  client_name 'MyApp/1.0'
+
+  http_options(
+    cache: {
+      server: 'localhost:11211',
+      namespace: 'myapp',
+      expires_in: 300
+    }
+  )
+
+  # ... schema ...
+end
+```
+
+### Error Handling
+
+```ruby
+begin
+  post = Post.find(999)
+rescue Hawk::Error::NotFound => e
+  puts "Post not found: #{e.message}"
+rescue Hawk::Error::Timeout => e
+  puts "Request timed out: #{e.message}"
+rescue Hawk::Error::HTTP => e
+  puts "HTTP error #{e.code}: #{e.message}"
+end
+```
+
+### Persisting Records
+
+```ruby
+post = Post.new(title: "Hello", body: "World")
+post.save! # Sends PUT request to API
+post.persisted? # => true
+
+# Track changes
+post.title = "Updated"
+post.changed? # => true
+post.changes # => { "title" => ["Hello", "Updated"] }
+```
+
+### Instrumentation
+
+Hawk logs HTTP requests to stderr by default. You can suppress this output:
+
+```ruby
+Hawk::HTTP::Instrumentation.suppress_verbose_output true
+```
 
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `bin/console` for an interactive prompt that will allow you to experiment.
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release` to create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+To install this gem onto your local machine, run `bundle exec rake install`. To build a local gem artifact, update the version number in `lib/hawk/version.rb` and then run `bundle exec rake build`.
 
 ## Contributing
 

--- a/lib/hawk/error.rb
+++ b/lib/hawk/error.rb
@@ -2,63 +2,122 @@
 
 module Hawk
   ##
-  # Represents an error.
+  # Base error class for all Hawk errors. Provides a hierarchy of
+  # specific error types for different failure scenarios.
+  #
+  # @example Rescuing Hawk errors
+  #   begin
+  #     post = Post.find(999)
+  #   rescue Hawk::Error::NotFound => e
+  #     puts "Post not found: #{e.message}"
+  #   rescue Hawk::Error::Timeout => e
+  #     puts "Request timed out: #{e.message}"
+  #   rescue Hawk::Error::HTTP => e
+  #     puts "HTTP error #{e.code}: #{e.message}"
+  #   end
   #
   class Error < StandardError
-    # Usage error
+    ##
+    # Raised when there is a configuration error, such as missing URL
+    # or invalid options.
     #
+    # @example
+    #   raise Hawk::Error::Configuration, "URL is not set"
     class Configuration < self
     end
 
-    # Timeout occurrew when fetching from the remote HTTP server.
+    ##
+    # Raised when a timeout occurs while fetching from the remote HTTP server.
+    # This can be either a connection timeout or a request timeout.
     #
+    # @example
+    #   raise Hawk::Error::Timeout, "Request timed out after 30 seconds"
     class Timeout < self
     end
 
+    ##
+    # Represents an HTTP error with a specific status code. This is the
+    # base class for all HTTP-specific error types.
+    #
+    # @attr_reader code [Integer] the HTTP status code
     class HTTP < self
+      ##
+      # Initializes a new HTTP error with the given code and message.
+      #
+      # @param code [Integer] the HTTP status code
+      # @param message [String] the error message
       def initialize(code, message)
         @code = code
         super(message)
       end
 
+      ##
+      # Returns the HTTP status code.
+      #
+      # @return [Integer] the HTTP status code
       attr_reader :code
     end
 
-    # Empty response from server.
+    ##
+    # Raised when the server returns an empty response (status code 0).
     #
+    # @example
+    #   raise Hawk::Error::Empty, "Empty response from server"
     class Empty < HTTP
+      ##
+      # @param message [String] the error message
       def initialize(message)
         super(0, message)
       end
     end
 
-    # Server bailed with a 500.
+    ##
+    # Raised when the server returns a 500 Internal Server Error.
     #
+    # @example
+    #   raise Hawk::Error::InternalServerError, "Server error"
     class InternalServerError < HTTP
+      ##
+      # @param message [String] the error message
       def initialize(message)
         super(500, message)
       end
     end
 
-    # Server bailed with a 400
+    ##
+    # Raised when the server returns a 400 Bad Request.
     #
+    # @example
+    #   raise Hawk::Error::BadRequest, "Invalid parameters"
     class BadRequest < HTTP
+      ##
+      # @param message [String] the error message
       def initialize(message)
         super(400, message)
       end
     end
 
-    # Server bailed with a 404
+    ##
+    # Raised when the server returns a 404 Not Found.
     #
+    # @example
+    #   raise Hawk::Error::NotFound, "Resource not found"
     class NotFound < HTTP
+      ##
+      # @param message [String] the error message
       def initialize(message)
         super(404, message)
       end
     end
 
-    # Server bailed with a 403
+    ##
+    # Raised when the server returns a 403 Forbidden.
     #
+    # @example
+    #   raise Hawk::Error::Forbidden, "Access denied"
     class Forbidden < HTTP
+      ##
+      # @param message [String] the error message
       def initialize(message)
         super(403, message)
       end

--- a/lib/hawk/http.rb
+++ b/lib/hawk/http.rb
@@ -9,12 +9,26 @@ module Hawk
   require_relative 'http/instrumentation'
 
   ##
-  # Represent an HTTP connector, to be linked to a {Model}.
+  # Represents an HTTP connector, to be linked to a {Model}. Handles all
+  # HTTP communication with remote API endpoints, including request building,
+  # response parsing, error handling, and optional caching via Memcached.
   #
+  # @example Creating an HTTP client
+  #   client = Hawk::HTTP.new("https://api.example.org/", timeout: 30)
+  #   client.get("posts/1")
+  #
+  # @example Posting data
+  #   client.post("posts", title: "Hello", body: "World")
+  #
+  # @see Hawk::Model::Connection
   class HTTP
     prepend Caching
     include Instrumentation
 
+    ##
+    # Default configuration options for HTTP requests.
+    #
+    # @return [Hash] default options with timeout, connect_timeout, and params_encoding
     DEFAULTS = {
       timeout: 2,
       connect_timeout: 1,
@@ -23,8 +37,28 @@ module Hawk
       # password:      nil,
     }.freeze
 
+    ##
+    # Valid URI schemes supported by Hawk.
+    #
+    # @return [Array<String>] list of supported schemes
     VALID_SCHEMES = %w[http https].freeze
 
+    ##
+    # Initializes a new HTTP client instance with the given base URL and options.
+    #
+    # @param base [String] the base URL for the HTTP client (must include a valid scheme)
+    # @param options [Hash] optional configuration settings to override defaults
+    # @option options [Integer] :timeout (2) maximum time in seconds to wait for a response
+    # @option options [Integer] :connect_timeout (1) maximum time in seconds to wait for connection
+    # @option options [Symbol] :params_encoding (:rack) encoding format for request parameters
+    # @option options [String] :username username for basic authentication
+    # @option options [String] :password password for basic authentication
+    # @option options [Hash] :cache Memcached caching configuration
+    #
+    # @raise [Hawk::Error::Configuration] if the base URL has an invalid scheme
+    #
+    # @example
+    #   client = Hawk::HTTP.new("https://api.example.org", timeout: 30)
     def initialize(base, options = {})
       @defaults = DEFAULTS.deep_merge(options)
 
@@ -39,52 +73,128 @@ module Hawk
       end
     end
 
+    ##
+    # The base URL for this HTTP client.
+    #
+    # @return [URI] the base URL
     attr_reader :base, :defaults
 
+    ##
+    # Returns a string representation of the HTTP client.
+    #
+    # @return [String] a human-readable representation
     def inspect
       "#<#{self.class.name} to #{base}>"
     end
 
+    ##
+    # Performs a GET request and returns the parsed JSON response.
+    #
+    # @param path [String] the URL path to request
+    # @param params [Hash] query parameters
+    # @return [Object] parsed JSON response
     def get(path, params = {})
       parse raw_get(path, params)
     end
 
+    ##
+    # Performs a GET request and returns the raw response body.
+    #
+    # @param path [String] the URL path to request
+    # @param params [Hash] query parameters
+    # @return [String] raw response body
     def raw_get(path, params = {})
       request('GET', path, params)
     end
 
+    ##
+    # Performs a POST request and returns the parsed JSON response.
+    #
+    # @param path [String] the URL path to request
+    # @param params [Hash] request body parameters
+    # @return [Object] parsed JSON response
     def post(path, params = {})
       parse raw_post(path, params)
     end
 
+    ##
+    # Performs a POST request and returns the raw response body.
+    #
+    # @param path [String] the URL path to request
+    # @param params [Hash] request body parameters
+    # @return [String] raw response body
     def raw_post(path, params = {})
       request('POST', path, params)
     end
 
+    ##
+    # Performs a PUT request and returns the parsed JSON response.
+    #
+    # @param path [String] the URL path to request
+    # @param params [Hash] request body parameters
+    # @return [Object] parsed JSON response
     def put(path, params = {})
       parse raw_put(path, params)
     end
 
+    ##
+    # Performs a PUT request and returns the raw response body.
+    #
+    # @param path [String] the URL path to request
+    # @param params [Hash] request body parameters
+    # @return [String] raw response body
     def raw_put(path, params = {})
       request('PUT', path, params)
     end
 
+    ##
+    # Performs a PATCH request and returns the parsed JSON response.
+    #
+    # @param path [String] the URL path to request
+    # @param params [Hash] request body parameters
+    # @return [Object] parsed JSON response
     def patch(path, params = {})
       parse raw_patch(path, params)
     end
 
+    ##
+    # Performs a PATCH request and returns the raw response body.
+    #
+    # @param path [String] the URL path to request
+    # @param params [Hash] request body parameters
+    # @return [String] raw response body
     def raw_patch(path, params = {})
       request('PATCH', path, params)
     end
 
+    ##
+    # Performs a DELETE request and returns the parsed JSON response.
+    #
+    # @param path [String] the URL path to request
+    # @param params [Hash] query parameters
+    # @return [Object] parsed JSON response
     def delete(path, params = {})
       parse raw_delete(path, params)
     end
 
+    ##
+    # Performs a DELETE request and returns the raw response body.
+    #
+    # @param path [String] the URL path to request
+    # @param params [Hash] query parameters
+    # @return [String] raw response body
     def raw_delete(path, params = {})
       request('DELETE', path, params)
     end
 
+    ##
+    # Calculates the total URL length for a request, useful for determining
+    # if a GET request should be converted to POST (when URL exceeds 2000 chars).
+    #
+    # @param path [String] the URL path
+    # @param method [Symbol] HTTP method (default: :get)
+    # @param options [Hash] request options
+    # @return [Integer] the total URL length
     def url_length(path, method = :get, options = {})
       url        = build_url(path)
       request    = build_request_options_from(method.to_s.upcase, options)
@@ -93,10 +203,22 @@ module Hawk
 
     protected
 
+    ##
+    # Parses a JSON response body.
+    #
+    # @param body [String] the JSON response body
+    # @return [Object] parsed JSON data
     def parse(body)
       MultiJson.load(body)
     end
 
+    ##
+    # Executes an HTTP request with caching and instrumentation.
+    #
+    # @param method [String] HTTP method (GET, POST, PUT, PATCH, DELETE)
+    # @param path [String] the URL path
+    # @param options [Hash] request options
+    # @return [String] raw response body
     def request(method, path, options)
       url        = build_url(path)
       cache_opts = options.delete(:cache) || {}
@@ -115,10 +237,26 @@ module Hawk
 
     private
 
+    ##
+    # Builds a complete URL by merging the base URL with a path.
+    #
+    # @param path [String] the URL path
+    # @return [String] the complete URL
     def build_url(path)
       base.merge(path.delete_prefix('/').squeeze('/')).to_s
     end
 
+    ##
+    # Handles HTTP responses, raising appropriate errors for non-success status codes.
+    #
+    # @param response [Typhoeus::Response] the HTTP response
+    # @raise [Hawk::Error::Timeout] if the request timed out
+    # @raise [Hawk::Error::Empty] if the response is empty
+    # @raise [Hawk::Error::BadRequest] for 400 status codes
+    # @raise [Hawk::Error::Forbidden] for 403 status codes
+    # @raise [Hawk::Error::NotFound] for 404 status codes
+    # @raise [Hawk::Error::InternalServerError] for 500 status codes
+    # @raise [Hawk::Error::HTTP] for other non-success status codes
     def response_handler(response)
       return if response.success?
 
@@ -156,6 +294,11 @@ module Hawk
       end
     end
 
+    ##
+    # Attempts to parse an application-level error message from the response body.
+    #
+    # @param body [String] the response body
+    # @return [String, nil] the parsed error message, or nil if parsing fails
     def parse_app_error_from(body)
       if body[0] == '{' && body[-1] == '}'
         resp = begin
@@ -172,6 +315,12 @@ module Hawk
       end
     end
 
+    ##
+    # Builds request options from the given HTTP method and options hash.
+    #
+    # @param method [String] HTTP method
+    # @param options [Hash] request options
+    # @return [Hash] formatted request options for Typhoeus
     def build_request_options_from(method, options)
       options = options.dup
 
@@ -210,10 +359,19 @@ module Hawk
       end
     end
 
+    ##
+    # Returns frozen default options formatted for Typhoeus.
+    #
+    # @return [Hash] Typhoeus-compatible options
     def typhoeus_defaults
       @typhoeus_defaults ||= options_for_typhoeus(defaults).freeze
     end
 
+    ##
+    # Converts Hawk options to Typhoeus-compatible options.
+    #
+    # @param hawk_options [Hash] Hawk configuration options
+    # @return [Hash] Typhoeus-compatible options
     def options_for_typhoeus(hawk_options)
       hawk_options.each_with_object({}) do |(opt, val), ret|
         case opt

--- a/lib/hawk/http/caching.rb
+++ b/lib/hawk/http/caching.rb
@@ -4,7 +4,29 @@ require 'dalli'
 
 module Hawk
   class HTTP
+    ##
+    # Provides Memcached-based caching for HTTP requests. Caches GET request
+    # responses and supports cache invalidation for mutations.
+    #
+    # @example Configuring caching
+    #   client = Hawk::HTTP.new("https://api.example.com/",
+    #     cache: {
+    #       server: 'localhost:11211',
+    #       namespace: 'myapp',
+    #       expires_in: 300
+    #     }
+    #   )
+    #
+    # @example Disabling caching
+    #   client = Hawk::HTTP.new("https://api.example.com/",
+    #     cache: { disabled: true }
+    #   )
+    #
     module Caching
+      ##
+      # Default cache configuration options.
+      #
+      # @return [Hash] default cache options
       DEFAULTS = {
         server: 'localhost:11211',
         namespace: 'hawk',
@@ -13,6 +35,8 @@ module Hawk
         serializer: MultiJson
       }.freeze
 
+      ##
+      # Initializes the caching module with the given options.
       def initialize(*)
         super
 
@@ -20,6 +44,10 @@ module Hawk
         initialize_cache(DEFAULTS.deep_merge(options))
       end
 
+      ##
+      # Returns a string representation including cache status.
+      #
+      # @return [String] human-readable representation
       def inspect
         description = if cache_configured?
                         "cache: ON #{@_cache_server} v#{@_cache_version}"
@@ -30,16 +58,31 @@ module Hawk
         super.sub(/>$/, ", #{description}>")
       end
 
+      ##
+      # Returns whether caching is configured and enabled.
+      #
+      # @return [Boolean] true if caching is enabled
       def cache_configured?
         !@_cache.nil?
       end
 
+      ##
+      # Returns the cache configuration options.
+      #
+      # @return [Hash] the cache options
       def cache_options
         @_cache_options
       end
 
       protected
 
+      ##
+      # Executes a block with caching support. Returns cached results for
+      # GET requests and stores new results in the cache.
+      #
+      # @param descriptor [Hash] request descriptor with url, method, params
+      # @yield block to execute if not cached
+      # @return [Object] cached or fresh response
       def caching(descriptor, &block)
         return yield unless cache_configured?
 
@@ -54,10 +97,21 @@ module Hawk
 
       private
 
+      ##
+      # Generates a cache key from the request descriptor.
+      #
+      # @param descriptor [Hash] request descriptor
+      # @return [String] the cache key
       def cache_key(descriptor)
         MultiJson.dump(descriptor)
       end
 
+      ##
+      # Tries to fetch from cache or execute the block and cache the result.
+      #
+      # @param descriptor [Hash] request descriptor
+      # @yield block to execute if not cached
+      # @return [Object] cached or fresh response
       def try_cache(descriptor)
         return yield unless descriptor[:method] == 'GET'
 
@@ -78,6 +132,10 @@ module Hawk
         end
       end
 
+      ##
+      # Invalidates cache entries for the given descriptor.
+      #
+      # @param descriptor [Hash] request descriptor with :invalidate paths
       def invalidate(descriptor)
         descriptor = descriptor.dup
         descriptor[:method] = 'GET'
@@ -95,6 +153,10 @@ module Hawk
         end
       end
 
+      ##
+      # Initializes the Memcached client connection.
+      #
+      # @param options [Hash] cache configuration options
       def initialize_cache(options)
         return if options[:disabled]
 
@@ -112,6 +174,11 @@ module Hawk
         end
       end
 
+      ##
+      # Establishes a connection to the Memcached server.
+      #
+      # @param options [Hash] cache configuration options
+      # @return [Array(Dalli::Client, String, String), nil] client, server, version or nil
       def connect_cache(options)
         static_options = options.dup
         static_options.delete(:expires_in)
@@ -129,6 +196,10 @@ module Hawk
         end
       end
 
+      ##
+      # Returns the cache servers registry.
+      #
+      # @return [Hash] cache server connections
       def cache_servers
         @@cache_servers ||= {}
       end

--- a/lib/hawk/http/instrumentation.rb
+++ b/lib/hawk/http/instrumentation.rb
@@ -4,7 +4,22 @@ require 'cgi/escape'
 
 module Hawk
   class HTTP
+    ##
+    # Provides request instrumentation and logging for Hawk HTTP requests.
+    # Logs request details including method, URL, elapsed time, and cache status.
+    #
+    # @example Suppressing verbose output
+    #   Hawk::HTTP::Instrumentation.suppress_verbose_output true
+    #
+    # @example Using with Instrumenter gem
+    #   # If the Instrumenter gem is available, it will be used automatically
+    #   # for more advanced instrumentation
+    #
     module Instrumentation
+      ##
+      # Includes the appropriate instrumentation module based on available gems.
+      #
+      # @param base [Class] the HTTP class to instrument
       def self.included(base)
         # https://github.com/ifad/instrumenter
         if defined?(::Instrumenter)
@@ -14,6 +29,11 @@ module Hawk
         end
       end
 
+      ##
+      # Controls whether verbose output is suppressed.
+      #
+      # @param value [Boolean, nil] true to suppress, false to enable, nil to query
+      # @return [Boolean] current suppression state
       def self.suppress_verbose_output(value = nil)
         if value.nil?
           @suppress_verbose_output
@@ -22,9 +42,25 @@ module Hawk
         end
       end
 
+      ##
+      # Basic instrumentation that logs request details to stderr.
+      #
+      # @example
+      #   # Output format:
+      #   # >> Hawk request: GET https://api.example.com/posts (123.45ms), cache MISS
+      #
       module Basic
+        ##
+        # Log format for request output.
         LOG_FORMAT = ">> \033[1mHawk %<type>s: %<method>s %<url>s (%<elapsed>.2fms), cache %<cached>s\033[0m\n"
 
+        ##
+        # Instruments a request by logging its details.
+        #
+        # @param type [Symbol] the instrumentation type (e.g., :request)
+        # @param payload [Hash] request details (url, method, params)
+        # @yield block to execute and measure
+        # @return [Object] the block's return value
         def instrument(type, payload)
           if Hawk::HTTP::Instrumentation.suppress_verbose_output
             yield payload

--- a/lib/hawk/linker.rb
+++ b/lib/hawk/linker.rb
@@ -1,24 +1,52 @@
 # frozen_string_literal: true
 
 module Hawk
+  ##
   # Allows adding to any Ruby object an accessor referencing an {Hawk::Model}.
   #
-  # Example, assuming Bar is defined and Foo responds_to +bar_id+:
+  # This module provides a convenient way to define resource accessors that
+  # lazily load and memoize associated Hawk models based on ID attributes.
   #
-  #     class Foo
-  #       include Hawk::Linker
+  # @example Defining a monomorphic resource accessor
+  #   class Foo
+  #     include Hawk::Linker
   #
-  #       resource_accessor :bar
-  #     end
+  #     resource_accessor :bar
+  #   end
   #
-  # Now, Foo#bar will call Bar.find(bar_id) and memoize it
+  #   # Now, Foo#bar will call Bar.find(bar_id) and memoize it
+  #
+  # @example Defining a polymorphic resource accessor
+  #   class Image
+  #     include Hawk::Linker
+  #
+  #     resource_accessor :imageable, polymorphic: true
+  #   end
   #
   module Linker
+    ##
+    # Extends the including class with class-level resource accessor macros.
+    #
+    # @param base [Class] the class including the linker helpers
     def self.included(base)
       base.extend(ClassMethods)
     end
 
+    ##
+    # Class-level macros for defining resource accessors.
     module ClassMethods
+      ##
+      # Defines a method to access a resource for a given entity, with support
+      # for both polymorphic and monomorphic resource accessors.
+      #
+      # @param entity [Symbol] the entity name for which the accessor is defined
+      # @param options [Hash] options to customize the accessor behavior
+      # @option options [Boolean] :polymorphic (false) if true, uses polymorphic accessor
+      # @option options [String] :class_name the class name to use (defaults to entity name camelize)
+      # @option options [String] :primary_key the primary key (defaults to <tt>"#{entity}_id"</tt>)
+      # @option options [String] :as the base name for polymorphic type/id columns
+      #
+      # @return [void]
       def resource_accessor(entity, options = {}) # Let's start simple.
         if options[:polymorphic]
           _polymorphic_resource_accessor(entity, options)
@@ -29,6 +57,12 @@ module Hawk
 
       private
 
+      ##
+      # Defines a monomorphic resource accessor with getter, setter, and reloader methods.
+      #
+      # @param entity [Symbol] the entity name
+      # @param options [Hash] accessor options
+      # @return [void]
       def _monomorphic_resource_accessor(entity, options)
         klass = options[:class_name] || entity.to_s.camelize
         key   = options[:primary_key] || [entity, :id].join('_')
@@ -62,6 +96,12 @@ module Hawk
         RUBY
       end
 
+      ##
+      # Defines a polymorphic resource accessor with getter, setter, and reloader methods.
+      #
+      # @param entity [Symbol] the entity name
+      # @param options [Hash] accessor options
+      # @return [void]
       def _polymorphic_resource_accessor(entity, options)
         key = options[:as] || entity
 

--- a/lib/hawk/model.rb
+++ b/lib/hawk/model.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 module Hawk
+  ##
+  # Namespace for all Model-related functionalities. This module contains
+  # the core components for defining API client models, including schema
+  # definitions, associations, querying, and connection management.
+  #
+  # @see Hawk::Model::Base
   module Model
     autoload :Base,           'hawk/model/base'
     autoload :Schema,         'hawk/model/schema'

--- a/lib/hawk/model/active.rb
+++ b/lib/hawk/model/active.rb
@@ -4,7 +4,26 @@ require 'active_model'
 
 module Hawk
   module Model
+    ##
+    # Integrates Hawk models with ActiveModel, providing persistence,
+    # dirty tracking, and equality comparison based on IDs.
+    #
+    # @example Using ActiveModel features
+    #   post = Post.new(title: "Hello")
+    #   post.persisted? # => true (always, for now)
+    #   post.save! # => PUT request to API
+    #
+    #   # Dirty tracking
+    #   post.title = "Updated"
+    #   post.changed? # => true
+    #   post.changes # => { "title" => ["Hello", "Updated"] }
+    #
     module Active
+      ##
+      # Extends the including model with ActiveModel naming, conversion,
+      # translation, and dirty tracking behaviour.
+      #
+      # @param base [Class] the model class including the Active integration
       def self.included(base)
         base.instance_eval do
           extend ActiveModel::Naming
@@ -20,6 +39,12 @@ module Hawk
         end
       end
 
+      ##
+      # Compares two model instances by class and ID.
+      #
+      # @param other [Object] the object to compare with
+      # @return [Boolean] true if both instances have the same class and ID
+      # @raise [Hawk::Error] if the model doesn't have an id attribute
       def ==(other)
         unless respond_to?(:id)
           raise Error, "Can't compare #{self} as it doesn't have an .id attribute"
@@ -29,6 +54,10 @@ module Hawk
       end
       alias eql? ==
 
+      ##
+      # Returns a hash value based on the ID for use in hashes and sets.
+      #
+      # @return [Integer] the hash value
       def hash
         if respond_to?(:id) && !id.nil?
           id.hash
@@ -37,27 +66,50 @@ module Hawk
         end
       end
 
+      ##
+      # Returns whether the model is persisted.
+      #
+      # @return [Boolean] always true (naive implementation for now)
       def persisted?
         true # Naive, for now.
       end
 
+      ##
+      # Writes an attribute value and marks it as changed.
+      #
+      # @param name [String, Symbol] the attribute name
+      # @param value [Object] the value to set
       def write_attribute(name, value)
         attribute_will_change!(name)
         super
       end
 
+      ##
+      # Saves the model to the API using a PUT request.
+      #
+      # @return [Boolean] true on success
+      # @raise [Hawk::Error] on failure
       def save!
         persist!
         changes_applied
         true
       end
 
+      ##
+      # Saves the model, returning false on failure instead of raising.
+      #
+      # @return [Boolean] true on success, false on failure
       def save
         save!
       rescue Hawk::Error
         false
       end
 
+      ##
+      # Persists the model by sending a PUT request to the API.
+      #
+      # @return [Object] the API response
+      # @raise [Hawk::Error] on failure
       def persist!
         connection.put(path_for(nil), attributes.merge(cache: { invalidate: path_for(nil) }))
       end

--- a/lib/hawk/model/association.rb
+++ b/lib/hawk/model/association.rb
@@ -2,17 +2,36 @@
 
 module Hawk
   module Model
+    ##
+    # Provides ActiveRecord-like association methods for Hawk models.
+    # Supports `has_many`, `has_one`, `belongs_to`, and polymorphic associations.
+    #
+    # @example Defining associations
+    #   class Post < Hawk::Model::Base
+    #     has_many :comments
+    #     belongs_to :author
+    #     has_one :image, as: :imageable
+    #   end
+    #
+    #   class Comment < Hawk::Model::Base
+    #     belongs_to :post
+    #   end
+    #
     module Association
-      # Initialize the associations registry
+      ##
+      # Initializes the associations registry.
       #
+      # @param base [Class] the model class
       def self.included(base)
         base.extend ClassMethods
         base.instance_eval { @_associations ||= {} }
       end
 
-      # Load associations early, to memoize them and avoid having
-      # Hashes when a Model is more appropriate.
+      ##
+      # Preloads associations when a new entity is instantiated.
       #
+      # @param attributes [Hash] model attributes
+      # @param params [Hash] additional parameters
       def initialize(attributes = {}, params = {})
         super
         if attributes.present? && self.class.associations?
@@ -22,10 +41,22 @@ module Hawk
 
       private
 
+      ##
+      # Preloads associations from the given attributes.
+      #
+      # @param attributes [Hash] model attributes
+      # @param _params [Hash] additional parameters (unused)
+      # @param scope [Class] the model class
       def preload_associations(attributes, _params, scope)
         instance_exec(scope, attributes, &scope.preload_association)
       end
 
+      ##
+      # Adds an association object to the model instance.
+      #
+      # @param scope [Class] the model class
+      # @param name [String, Symbol] the association name
+      # @param repr [Hash, Array] the association representation
       def add_association_object(scope, name, repr)
         associations = scope.associations
 
@@ -46,10 +77,20 @@ module Hawk
         end
       end
 
+      ##
+      # Checks if the association type is a collection.
+      #
+      # @param type [Symbol] the association type
+      # @return [Boolean] true if the association is a collection
       def is_collection?(type)
         %i[polymorphic_belongs_to has_many].include? type
       end
 
+      ##
+      # Adds records to an association collection.
+      #
+      # @param name [String, Symbol] the association name
+      # @param target [Array, Base] the records to add
       def add_to_association_collection(name, target)
         variable = "@_#{name}"
         instance_variable_set(variable, Collection.new) unless instance_variable_defined?(variable)
@@ -57,19 +98,34 @@ module Hawk
         target.respond_to?(:each) ? collection.concat(target) : collection.push(target)
       end
 
+      ##
+      # Sets the value of a single association.
+      #
+      # @param name [String, Symbol] the association name
+      # @param target [Base] the associated record
       def set_association_value(name, target)
         instance_variable_set(:"@_#{name}", target)
       end
 
+      ##
+      # Cleans inherited params for associations.
+      #
+      # @param inherited [Hash] inherited parameters
+      # @param opts [Hash] additional options
+      # @return [Hash] cleaned parameters
       def clean_inherited_params(inherited, opts = {})
         rv = {}.deep_merge opts
         rv[:options] = inherited[:options] if inherited && inherited[:options]
         rv
       end
 
+      ##
+      # Class-level association definition and inheritance helpers.
       module ClassMethods
-        # Propagate associations to the subclasses on inheritance
+        ##
+        # Propagates associations to subclasses on inheritance.
         #
+        # @param subclass [Class] the subclass
         def inherited(subclass)
           super
 
@@ -87,33 +143,29 @@ module Hawk
           end
         end
 
+        ##
         # Defines how associations should be preloaded.
         #
         # The given block gets called when a new entity is instantiated, and
         # it gets passed the object attributes, the association's name, type
         # and options.
         #
-        # Example (for Joe :-)
+        # @yield [scope, attributes, name, type, options] block to preload associations
+        # @return [Proc] the preloading block
         #
-        #     class Foo < Hawk::Model::Base
-        #       has_many :bars
+        # @example Custom preloading
+        #   class Foo < Hawk::Model::Base
+        #     has_many :bars
         #
-        #       preload_association do |attributes, name, type, options|
-        #         if attributes.key?('links')
-        #           links = attributes['links']
-        #           if links.key?(name)
-        #             return attributes.delete(links[name])
-        #           end
+        #     preload_association do |attributes, name, type, options|
+        #       if attributes.key?('links')
+        #         links = attributes['links']
+        #         if links.key?(name)
+        #           return attributes.delete(links[name])
         #         end
         #       end
         #     end
-        #
-        # The block would get called once, with :bars as +name+, :has_many as
-        # +type+ and +{ class_name: "Bar", primary_key : "foo_id" }+ as +options+.
-        #
-        # By default it looks up in the representation a property named after
-        # the association's name and returns it, deleting it from the repr.
-        #
+        #   end
         def preload_association(&block)
           @preload_association = block if block
           @preload_association ||= lambda do |scope, attributes|
@@ -129,27 +181,48 @@ module Hawk
           end
         end
 
-        # Return a copy of the associations registry
+        ##
+        # Returns a copy of the associations registry.
         #
+        # @return [Hash] the associations hash
         def associations
           @_associations.dup
         end
 
-        # Check whether associations are defined
+        ##
+        # Checks whether associations are defined.
         #
+        # @return [Boolean] true if associations are defined
         def associations?
           @_associations.present?
         end
 
-        # Check whether the given attribute is an association
+        ##
+        # Checks whether the given attribute is an association.
         #
+        # @param attribute [String, Symbol] the attribute name
+        # @return [Boolean] true if the attribute is an association
         def association?(attribute)
           @_associations.key?(attribute.to_sym)
         end
 
-        # Adds an has_many association, mimicking ActiveRecord's interface
-        # TODO better documentation
+        ##
+        # Defines a has_many association.
         #
+        # @param entities [Symbol] the plural entity name
+        # @param options [Hash] association options
+        # @option options [String] :class_name the class name (defaults to entity name camelize)
+        # @option options [String] :primary_key the foreign key (defaults to the current model name followed by <tt>_id</tt>)
+        # @option options [String] :from the endpoint path to query
+        # @option options [String] :as the polymorphic base name
+        #
+        # @example
+        #   class Post < Hawk::Model::Base
+        #     has_many :comments
+        #   end
+        #
+        #   post = Post.find(1)
+        #   post.comments.all # => [...]
         def has_many(entities, options = {})
           entity = entities.to_s.singularize
           klass  = options[:class_name] || entity.camelize
@@ -161,13 +234,24 @@ module Hawk
           _define_association(entities, :has_many, class_name: klass, primary_key: key, from: from, as: as)
         end
 
-        # Adds an has_one association, mimicking ActiveRecord's interface
+        ##
+        # Defines a has_one association.
         #
-        # Specifies a one-to-one association with another class. This method
-        # should only be used if the other class contains the foreign key. If
-        # the current class contains the foreign key, then you should use
-        # belongs_to instead.
+        # @param entity [Symbol] the singular entity name
+        # @param options [Hash] association options
+        # @option options [String] :class_name the class name (defaults to entity name camelize)
+        # @option options [String] :primary_key the foreign key (defaults to the current model name followed by <tt>_id</tt>)
+        # @option options [String] :from the endpoint path to query
+        # @option options [Boolean] :nested whether to use nested routing
+        # @option options [String] :as the polymorphic base name
         #
+        # @example
+        #   class Animal < Hawk::Model::Base
+        #     has_one :favourite_food, class_name: 'Food'
+        #   end
+        #
+        #   animal = Animal.find(1)
+        #   animal.favourite_food # => #<Food ...>
         def has_one(entity, options = {})
           entity = entity.to_s
           klass  = options[:class_name] || entity.camelize
@@ -180,19 +264,22 @@ module Hawk
           _define_association(entity, :has_one, class_name: klass, primary_key: key, from: from, nested: nested, as: as)
         end
 
-        # Adds a belongs_to association, mimicking ActiveRecord's interface.
+        ##
+        # Defines a belongs_to association.
         #
-        # Specifies a one-to-one association with another class. This method
-        # should only be used if this class contains the foreign key. If the
-        # other class contains the foreign key, then you should use has_one
-        # instead.
+        # @param entity [Symbol] the singular entity name
+        # @param options [Hash] association options
+        # @option options [String] :class_name the class name (defaults to entity name camelize)
+        # @option options [String] :primary_key the foreign key (defaults to <tt>"#{entity}_id"</tt>)
+        # @option options [Boolean] :polymorphic whether this is a polymorphic association
         #
-        # Options:
+        # @example
+        #   class Comment < Hawk::Model::Base
+        #     belongs_to :post
+        #   end
         #
-        # - class_name
-        # - primary_key
-        # - polymorphic
-        #
+        #   comment = Comment.find(1)
+        #   comment.post # => #<Post ...>
         def belongs_to(entity, options = {})
           if options[:polymorphic]
             polymorphic_belongs_to(entity, options)
@@ -203,6 +290,11 @@ module Hawk
 
         protected
 
+        ##
+        # Defines a monomorphic belongs_to association.
+        #
+        # @param entity [Symbol] the entity name
+        # @param options [Hash] association options
         def monomorphic_belongs_to(entity, options)
           klass  = options[:class_name] || entity.to_s.camelize
           key    = options[:primary_key] || [entity, :id].join('_')
@@ -211,6 +303,11 @@ module Hawk
           _define_association(entity, :monomorphic_belongs_to, class_name: klass, primary_key: key, params: params)
         end
 
+        ##
+        # Defines a polymorphic belongs_to association.
+        #
+        # @param entity [Symbol] the entity name
+        # @param options [Hash] association options
         def polymorphic_belongs_to(entity, options)
           key = [options[:as] || entity, :id].join('_')
           # TODO: params
@@ -220,13 +317,19 @@ module Hawk
 
         private
 
+        ##
+        # Defines an association with the given name, type, and options.
+        #
+        # @param name [Symbol] the association name
+        # @param type [Symbol] the association type
+        # @param options [Hash] association options
         def _define_association(name, type, options)
           @_associations[name.to_sym] = [type, options]
           instance_exec(name.to_s, options, &CODE.fetch(type))
         end
 
-        # The raw associations code
-        #
+        ##
+        # The raw association code implementations.
         CODE = {
           has_many: lambda { |entities, options|
             klass, key, from, as = options.values_at(:class_name, :primary_key, :from, :as)

--- a/lib/hawk/model/base.rb
+++ b/lib/hawk/model/base.rb
@@ -3,10 +3,37 @@
 module Hawk
   module Model
     ##
-    # Represents a remote entity, wrapped into a model holding each property in
-    # an instance variable, casting the JSON values to data types inferred from
-    # the property names themselves.
+    # Represents a remote entity, wrapped into a model holding each property
+    # in an instance variable, casting the JSON values to data types inferred
+    # from the property names themselves.
     #
+    # This is the primary base class for all Hawk models. It includes all
+    # necessary modules for schema definition, HTTP connections, querying,
+    # associations, and more.
+    #
+    # @example Defining a model
+    #   class User < Hawk::Model::Base
+    #     url 'https://api.example.com/'
+    #     client_name 'MyApp/1.0'
+    #
+    #     schema do
+    #       integer :id
+    #       string :name, :email
+    #       boolean :active
+    #     end
+    #
+    #     has_many :posts
+    #   end
+    #
+    # @example Using the model
+    #   user = User.find(1)
+    #   user.name   # => "John Doe"
+    #   user.active # => true
+    #
+    # @see Hawk::Model::Schema
+    # @see Hawk::Model::Connection
+    # @see Hawk::Model::Finder
+    # @see Hawk::Model::Querying
     class Base
       include Schema # First
       include Connection
@@ -19,10 +46,20 @@ module Hawk
       include Scoping
       include Active
 
+      ##
+      # Initializes a new model instance with the given attributes and params.
+      #
+      # @param attributes [Hash] attribute key-value pairs to initialize the model with
+      # @param params [Hash] additional parameters to pass through to associations
       def initialize(attributes = {}, params = {})
         super
       end
 
+      ##
+      # Returns a string representation of the model instance, showing all
+      # schema attributes and their values.
+      #
+      # @return [String] a human-readable representation
       def inspect
         result = "#<#{self.class.name}"
 

--- a/lib/hawk/model/collection.rb
+++ b/lib/hawk/model/collection.rb
@@ -2,7 +2,32 @@
 
 module Hawk
   module Model
+    ##
+    # A specialized Array subclass that holds a collection of Hawk model
+    # instances with additional metadata like total count, limit, and offset
+    # for pagination support.
+    #
+    # @example Working with collections
+    #   posts = Post.all
+    #   posts.total_count # => 100
+    #   posts.limit_value # => 25
+    #   posts.offset_value # => 0
+    #
+    #   posts.each { |post| puts post.title }
+    #
+    # @example Mapping preserves collection metadata
+    #   titles = posts.map(&:title)
+    #   titles.total_count # => 100
+    #
     class Collection < Array
+      ##
+      # Initializes a new collection with the given elements and options.
+      #
+      # @param elements [Array] the collection elements
+      # @param options [Hash] collection metadata
+      # @option options [Integer] :total_count total number of records available
+      # @option options [Integer] :limit the limit parameter used
+      # @option options [Integer] :offset the offset parameter used
       def initialize(elements = [], options = {})
         replace(elements)
 
@@ -11,20 +36,42 @@ module Hawk
         @offset_value = options[:offset].to_i
       end
 
+      ##
+      # Returns a string representation of the collection.
+      #
+      # @return [String] a human-readable representation
       def inspect
         "#<#{self.class.name} count:#{total_count} contents:#{super}>"
       end
 
+      ##
+      # Returns the total count of records available (not just in this page).
+      #
+      # @return [Integer, nil] the total count, or nil if not paginated
       attr_reader :total_count, :offset_value
 
+      ##
+      # Returns the limit value used for this collection.
+      #
+      # @return [Integer] the limit value
+      # @raise [Hawk::Error] if the collection is not paginated
       def limit_value
         @limit_value or raise Hawk::Error, 'This collection is not paginated'
       end
 
+      ##
+      # Returns the count of records in this collection, or total_count if available.
+      #
+      # @return [Integer] the record count
       def count
         total_count || super
       end
 
+      ##
+      # Maps the collection, preserving pagination metadata.
+      #
+      # @yield [element] each element in the collection
+      # @return [Collection] a new collection with mapped elements
       def map(&block)
         self.class.new(super,
                        total_count: @total_count,

--- a/lib/hawk/model/configurator.rb
+++ b/lib/hawk/model/configurator.rb
@@ -2,18 +2,55 @@
 
 module Hawk
   module Model
+    ##
+    # Provides configuration management for Hawk models and their subclasses.
+    # Allows setting configuration options that propagate to all subclasses.
+    #
+    # @example Configuring a model
+    #   class Base < Hawk::Model::Base
+    #     url 'https://api.example.com/'
+    #     client_name 'MyApp/1.0'
+    #   end
+    #
+    #   # Configuration propagates to subclasses
+    #   class Post < Base
+    #     # Inherits URL and client_name from Base
+    #   end
+    #
     module Configurator
+      ##
+      # Extends the including model with class-level configuration helpers.
+      #
+      # @param base [Class] the model class including the configurator
       def self.included(base)
         base.extend ClassMethods
       end
 
+      ##
+      # Class-level configuration APIs.
       module ClassMethods
+        ##
+        # Configures the model class and all its subclasses.
+        #
+        # @yield [model] block to configure each model
+        #
+        # @example
+        #   class Post < Hawk::Model::Base
+        #     configure do
+        #       url 'https://api.example.com/'
+        #       client_name 'MyApp/1.0'
+        #     end
+        #   end
         def configure(&block)
           ([self] + configurable).each do |model|
             model.instance_eval(&block)
           end
         end
 
+        ##
+        # Tracks subclasses for configuration propagation.
+        #
+        # @param subclass [Class] the subclass
         def inherited(subclass)
           super
 
@@ -22,6 +59,10 @@ module Hawk
 
         protected
 
+        ##
+        # Returns all configurable subclasses (recursively).
+        #
+        # @return [Array<Class>] all subclasses that should receive configuration
         def configurable
           (@_configurable ||= []).inject(Set.new) do |s, klass|
             s.add klass

--- a/lib/hawk/model/connection.rb
+++ b/lib/hawk/model/connection.rb
@@ -3,66 +3,151 @@
 module Hawk
   module Model
     ##
-    # Fetches models from the remote HTTP endpoint.
+    # Provides HTTP connection management for Hawk models. Handles
+    # URL configuration, HTTP options, and client naming.
+    #
+    # @example Configuring a model's connection
+    #   class Post < Hawk::Model::Base
+    #     url 'https://api.example.com/'
+    #     client_name 'MyApp/1.0'
+    #     http_options timeout: 30
+    #   end
     #
     module Connection
+      ##
+      # Extends the including model with class-level connection helpers.
+      #
+      # @param base [Class] the model class including the connection helpers
       def self.included(base)
         base.extend ClassMethods
       end
 
+      ##
+      # Initializes the model with connection parameters.
+      #
+      # @param attributes [Hash] model attributes
+      # @param params [Hash] additional parameters for associations
       def initialize(attributes = {}, params = {})
         @params = params || {}
 
         super
       end
+
+      ##
+      # Returns the parameters hash for this model instance.
+      #
+      # @return [Hash] the model parameters
       attr_reader :params
 
+      ##
+      # Returns the HTTP connection for this model class.
+      #
+      # @return [Hawk::HTTP] the HTTP connection
       def connection
         self.class.connection
       end
 
-      # These methods delegate to connection and path_for, but are
-      # included in both the instance and the class, and in both
-      # cases they reference the specialized implementation of
-      # path_for, class- or instance- level.
+      ##
+      # Shared HTTP methods that delegate to the connection. These methods
+      # are included in both instance and class contexts.
       #
       module SharedMethods
+        ##
+        # Performs a GET request through the connection.
+        #
+        # @param component [String] URL path component
+        # @param params [Hash] query parameters
+        # @return [Object] parsed JSON response
         def get(component, params = {})
           connection.get(path_for(component), params)
         end
 
+        ##
+        # Performs a raw GET request through the connection.
+        #
+        # @param component [String] URL path component
+        # @param params [Hash] query parameters
+        # @return [String] raw response body
         def raw_get(component, params = {})
           connection.raw_get(path_for(component), params)
         end
 
+        ##
+        # Performs a POST request through the connection.
+        #
+        # @param component [String] URL path component
+        # @param params [Hash] request body parameters
+        # @return [Object] parsed JSON response
         def post(component, params = {})
           connection.post(path_for(component), params)
         end
 
+        ##
+        # Performs a raw POST request through the connection.
+        #
+        # @param component [String] URL path component
+        # @param params [Hash] request body parameters
+        # @return [String] raw response body
         def raw_post(component, params = {})
           connection.raw_post(path_for(component), params)
         end
 
+        ##
+        # Performs a PUT request through the connection.
+        #
+        # @param component [String] URL path component
+        # @param params [Hash] request body parameters
+        # @return [Object] parsed JSON response
         def put(component, params = {})
           connection.put(path_for(component), params)
         end
 
+        ##
+        # Performs a raw PUT request through the connection.
+        #
+        # @param component [String] URL path component
+        # @param params [Hash] request body parameters
+        # @return [String] raw response body
         def raw_put(component, params = {})
           connection.raw_put(path_for(component), params)
         end
 
+        ##
+        # Performs a PATCH request through the connection.
+        #
+        # @param component [String] URL path component
+        # @param params [Hash] request body parameters
+        # @return [Object] parsed JSON response
         def patch(component, params = {})
           connection.patch(path_for(component), params)
         end
 
+        ##
+        # Performs a raw PATCH request through the connection.
+        #
+        # @param component [String] URL path component
+        # @param params [Hash] request body parameters
+        # @return [String] raw response body
         def raw_patch(component, params = {})
           connection.raw_patch(path_for(component), params)
         end
 
+        ##
+        # Performs a DELETE request through the connection.
+        #
+        # @param component [String] URL path component
+        # @param params [Hash] query parameters
+        # @return [Object] parsed JSON response
         def delete(component, params = {})
           connection.delete(path_for(component), params)
         end
 
+        ##
+        # Performs a raw DELETE request through the connection.
+        #
+        # @param component [String] URL path component
+        # @param params [Hash] query parameters
+        # @return [String] raw response body
         def raw_delete(component, params = {})
           connection.raw_delete(path_for(component), params)
         end
@@ -70,9 +155,16 @@ module Hawk
 
       include SharedMethods
 
+      ##
+      # Class-level connection configuration and request helpers.
       module ClassMethods
         include SharedMethods
 
+        ##
+        # Returns or creates the HTTP connection for this model class.
+        #
+        # @return [Hawk::HTTP] the HTTP connection
+        # @raise [Hawk::Error::Configuration] if URL or client_name is not set
         def connection
           @connection ||= begin
             raise Error::Configuration, "URL for #{name} is not yet set" unless url
@@ -86,6 +178,12 @@ module Hawk
           end
         end
 
+        ##
+        # Sets or returns the base URL for this model class.
+        # When set, the URL is propagated to all configurable subclasses.
+        #
+        # @param url [String, nil] the base URL
+        # @return [String, nil] the base URL
         def url(url = nil)
           @_url = url.dup.freeze if url
 
@@ -95,6 +193,12 @@ module Hawk
         end
         alias url= url
 
+        ##
+        # Sets or returns the HTTP options for this model class.
+        # When set, options are propagated to all configurable subclasses.
+        #
+        # @param options [Hash, nil] HTTP options to merge
+        # @return [Hash] the HTTP options
         def http_options(options = nil)
           @_http_options ||= {}
 
@@ -108,6 +212,12 @@ module Hawk
         end
         alias http_options= http_options
 
+        ##
+        # Sets or returns the client name (User-Agent) for this model class.
+        # When set, the name is propagated to all configurable subclasses.
+        #
+        # @param name [String, nil] the client name
+        # @return [String, nil] the client name
         def client_name(name = nil)
           @_client_name = name.dup.freeze if name
 
@@ -117,6 +227,8 @@ module Hawk
         end
         alias client_name= client_name
 
+        ##
+        # Inherits connection settings from parent class.
         def inherited(subclass)
           super
 

--- a/lib/hawk/model/finder.rb
+++ b/lib/hawk/model/finder.rb
@@ -2,16 +2,56 @@
 
 module Hawk
   module Model
+    ##
+    # Provides finder methods for locating records by ID or querying collections.
+    # Handles path building, record instantiation, and collection wrapping.
+    #
+    # @example Finding a single record
+    #   post = Post.find(1)
+    #
+    # @example Finding multiple records
+    #   posts = Post.find([1, 2, 3])
+    #
+    # @example Getting all records
+    #   posts = Post.all
+    #
+    # @example Getting a count
+    #   count = Post.count
+    #
     module Finder
+      ##
+      # Extends the including model with class-level finder methods.
+      #
+      # @param base [Class] the model class including the finder helpers
       def self.included(base)
         base.extend ClassMethods
       end
 
+      ##
+      # Builds the URL path for this model instance.
+      #
+      # @param component [String, nil] optional path component
+      # @param params [Hash] additional parameters
+      # @return [String] the full URL path
       def path_for(component, params = {})
         [self.class.model_path_from(params), id, component].compact.join('/')
       end
 
+      ##
+      # Class-level record lookup and instantiation helpers.
       module ClassMethods
+        ##
+        # Finds a record or multiple records by ID(s).
+        #
+        # @param id_or_ids [Integer, Array<Integer>] one or more record IDs
+        # @param params [Hash] additional query parameters
+        # @return [Base, Collection, nil] the found record(s)
+        #
+        # @example Finding a single record
+        #   post = Post.find(1)
+        #
+        # @example Finding multiple records
+        #   posts = Post.find([1, 2, 3])
         def find(id_or_ids, params = {})
           if id_or_ids.respond_to?(:each)
             find_many(id_or_ids, params)
@@ -20,15 +60,39 @@ module Hawk
           end
         end
 
+        ##
+        # Finds a single record by ID.
+        #
+        # @param id [Integer] the record ID
+        # @param params [Hash] additional query parameters
+        # @return [Base] the found record
+        # @raise [Hawk::Error::NotFound] if the record is not found
         def find_one(id, params = {})
           repr = connection.get(path_for(id, params), params)
           instantiate_one(repr, params)
         end
 
+        ##
+        # Finds multiple records by IDs using a batch query.
+        #
+        # @param ids [Array<Integer>] the record IDs
+        # @param params [Hash] additional query parameters
+        # @return [Collection] the found records
         def find_many(ids, params = {})
           all(params.deep_merge(id: ids))
         end
 
+        ##
+        # Returns all records, optionally with query parameters.
+        #
+        # @param params [Hash] query parameters
+        # @return [Collection] all records
+        #
+        # @example Getting all records
+        #   posts = Post.all
+        #
+        # @example With filters
+        #   posts = Post.all(published: true)
         def all(params = {})
           path = path_for(nil, params)
           if connection.url_length(path, :get, params) > 2000
@@ -39,6 +103,17 @@ module Hawk
           instantiate_many(repr, params)
         end
 
+        ##
+        # Returns the count of records, optionally with query parameters.
+        #
+        # @param params [Hash] query parameters
+        # @return [Integer] the record count
+        #
+        # @example Getting a count
+        #   count = Post.count
+        #
+        # @example With filters
+        #   count = Post.count(published: true)
         def count(params = {})
           params = {} unless params.is_a?(Hash)
           path = path_for(count_path, params)
@@ -47,10 +122,22 @@ module Hawk
           repr.fetch(count_key).to_i
         end
 
+        ##
+        # Builds the URL path for this model class.
+        #
+        # @param component [String, nil] optional path component
+        # @param params [Hash] additional parameters
+        # @return [String] the full URL path
         def path_for(component, params = {})
           [model_path_from(params), component].compact.join('/')
         end
 
+        ##
+        # Instantiates one or many records from a representation.
+        #
+        # @param repr [Hash, Array] the record representation(s)
+        # @param params [Hash] additional parameters
+        # @return [Base, Collection] the instantiated record(s)
         def instantiate_from(repr, params = {})
           if repr.is_a?(Array)
             instantiate_many(repr, params)
@@ -59,6 +146,12 @@ module Hawk
           end
         end
 
+        ##
+        # Instantiates multiple records from an array representation.
+        #
+        # @param repr [Array, Hash] the records representation
+        # @param params [Hash] additional parameters
+        # @return [Collection] the instantiated records
         def instantiate_many(repr, params)
           if repr.respond_to?(:key?)
             collection  = repr.key?(collection_key)  ? repr.fetch(collection_key)       : []
@@ -77,6 +170,12 @@ module Hawk
           Collection.new(collection.map! { |repr| instantiate_one(repr, params) }, collection_options)
         end
 
+        ##
+        # Instantiates a single record from its representation.
+        #
+        # @param repr [Hash] the record representation
+        # @param params [Hash] additional parameters
+        # @return [Base] the instantiated record
         def instantiate_one(repr, params)
           if repr.key?(instance_key) && repr[instance_key].is_a?(Hash)
             repr = repr.fetch(instance_key)
@@ -85,30 +184,59 @@ module Hawk
           new repr, params
         end
 
+        ##
+        # Returns the instance key (singularized class name).
+        #
+        # @return [String] the instance key
         def instance_key
           @instance_key ||= name.demodulize.underscore
         end
 
+        ##
+        # Returns the collection key (pluralized class name).
+        #
+        # @return [String] the collection key
         def collection_key
           @collection_key = instance_key.pluralize
         end
 
+        ##
+        # Returns the total count key for pagination.
+        #
+        # @return [String] the total count key
         def total_count_key
           @total_count_key = 'total_count'
         end
 
+        ##
+        # Returns the count key for count queries.
+        #
+        # @return [String] the count key
         def count_key
           @count_key = 'count'
         end
 
+        ##
+        # Returns the limit parameter name.
+        #
+        # @return [Symbol] the limit parameter name
         def limit_param
           :limit
         end
 
+        ##
+        # Returns the offset parameter name.
+        #
+        # @return [Symbol] the offset parameter name
         def offset_param
           :offset
         end
 
+        ##
+        # Returns the model path, considering any endpoint override.
+        #
+        # @param params [Hash] query parameters
+        # @return [String] the model path
         def model_path_from(params)
           if (from = params.dig(:options, :endpoint))
             from = [model_path, from].join('/') unless from[0] == '/'
@@ -118,6 +246,12 @@ module Hawk
           end
         end
 
+        ##
+        # Sets or returns the base path for this model's API endpoint.
+        #
+        # @param path [String, nil] the path to set
+        # @return [String] the model path
+        # @raise [Hawk::Error::Configuration] if called on Hawk::Model::Base
         def model_path(path = nil)
           if self == Hawk::Model::Base
             raise Error::Configuration, "Hawk's Base class doesn't have any path"
@@ -127,15 +261,29 @@ module Hawk
           @model_path ||= default_model_path
         end
 
+        ##
+        # Returns the default model path based on the class name.
+        #
+        # @return [String] the default model path
         def default_model_path
           name.demodulize.underscore.pluralize.freeze
         end
 
+        ##
+        # Sets or returns the batch path for batch queries.
+        #
+        # @param path [String, nil] the path to set
+        # @return [String] the batch path
         def batch_path(path = nil)
           @batch_path = path if path
           @batch_path ||= 'batch'
         end
 
+        ##
+        # Sets or returns the count path for count queries.
+        #
+        # @param path [String, nil] the path to set
+        # @return [String] the count path
         def count_path(path = nil)
           @count_path = path if path
           @count_path ||= 'count'

--- a/lib/hawk/model/lookup.rb
+++ b/lib/hawk/model/lookup.rb
@@ -2,57 +2,69 @@
 
 module Hawk
   module Model
+    ##
+    # Provides model class lookup functionality for resolving association
+    # targets. Searches within the model namespace, parent namespace, and
+    # inheritance chain to find the appropriate model class.
+    #
+    # @example Model class resolution
+    #   module Client
+    #     class Base < Hawk::Model::Base
+    #     end
+    #
+    #     class Post < Base
+    #       has_many :comments
+    #     end
+    #
+    #     class Comment < Base
+    #       belongs_to :post
+    #     end
+    #   end
+    #
+    #   module App
+    #     class Post < Client::Post
+    #     end
+    #
+    #     class Comment < Client::Comment
+    #     end
+    #   end
+    #
+    #   # Returns App::Comment when called from App::Post
+    #   App::Post.model_class_for('Comment')
+    #
+    #   # Returns Client::Comment when called from Client::Post
+    #   Client::Post.model_class_for('Comment')
+    #
     module Lookup
+      ##
+      # Extends the including model with class lookup helpers.
+      #
+      # @param base [Class] the model class including the lookup helpers
       def self.included(base)
         base.extend ClassMethods
       end
 
+      ##
+      # Class-level model resolution helpers.
       module ClassMethods
+        ##
+        # Inherits the class cache from the parent class.
         def inherited(subclass)
           super
           subclass.instance_eval { @_class_cache = {} }
         end
 
-        # Given
+        ##
+        # Resolves a model class by name, searching within the current
+        # namespace, parent namespace, and inheritance chain.
         #
-        #   module Client
-        #     module Base < Hawk::Model::Base
-        #     end
+        # @param name [String] the class name to resolve
+        # @param scope [Class] the scope to search from (default: self)
+        # @return [Class] the resolved model class
+        # @raise [Hawk::Error] if no suitable model is found
         #
-        #     module Post < Base
-        #       has_many :comments
-        #     end
-        #
-        #     module Comment < Base
-        #       belongs_to :post
-        #     end
-        #   end
-        #
-        #   module App
-        #     class Post < Client::Post
-        #     end
-        #
-        #     class Comment < Client::Comment
-        #     end
-        #   end
-        #
-        # Then
-        #
-        #   App::Post.model_class_for('Comment')
-        #
-        # will return +App::Comment+
-        #
-        # while
-        #
-        #   Client::Post.model_class_for('Comment')
-        #
-        # will return +Client::Comment+
-        #
-        # In a nutshell, first the model namespace is checked,
-        # then the containing namespace, and then the inheritance
-        # chain is walked up to the first class inheriting from
-        # Hawk::Model::Base.
-        #
+        # @example
+        #   Post.model_class_for('Comment') # => Comment
         def model_class_for(name, scope: self)
           cached_model_class_for(name, scope) do
             look_up_model_class(name, scope)
@@ -61,6 +73,13 @@ module Hawk
 
         private
 
+        ##
+        # Looks up a model class by name.
+        #
+        # @param name [String] the class name to resolve
+        # @param scope [Class] the scope to search from
+        # @return [Class] the resolved model class
+        # @raise [Hawk::Error] if no suitable model is found
         def look_up_model_class(name, scope)
           if self_constant = look_up_constant_in(name, scope)
             return self_constant
@@ -81,12 +100,25 @@ module Hawk
           end
         end
 
+        ##
+        # Attempts to find a constant within a given scope.
+        #
+        # @param name [String] the constant name
+        # @param scope [Class, Module] the scope to search in
+        # @return [Class, nil] the constant, or nil if not found
         def look_up_constant_in(name, scope)
           scope.module_parent.const_get(name)
         rescue NameError
           nil
         end
 
+        ##
+        # Caches the result of model class resolution.
+        #
+        # @param name [String] the class name
+        # @param scope [Class] the scope
+        # @yield block that returns the resolved class
+        # @return [Class] the cached model class
         def cached_model_class_for(name, scope)
           @_class_cache[[name, scope.name]] ||= yield
         end

--- a/lib/hawk/model/pagination.rb
+++ b/lib/hawk/model/pagination.rb
@@ -2,8 +2,27 @@
 
 module Hawk
   module Model
+    ##
+    # Provides pagination support for Hawk models. Integrates with Kaminari
+    # if available, otherwise provides basic pagination methods.
+    #
+    # @example Using pagination
+    #   posts = Post.limit(25).offset(50)
+    #   posts.current_page # => 3
+    #
+    # @example With Kaminari
+    #   posts = Post.page(2).per(25)
+    #   posts.total_count # => 100
+    #   posts.current_page # => 2
+    #
     module Pagination
+      ##
+      # Shared pagination helpers mixed into paginated proxies and collections.
       module Common
+        ##
+        # Returns the current page number based on offset and limit.
+        #
+        # @return [Integer] the current page number (1-indexed)
         def current_page
           if limit_value == 0
             1
@@ -14,6 +33,11 @@ module Hawk
       end
 
       if defined?(::Kaminari)
+        ##
+        # Extends the including model with Kaminari-compatible pagination
+        # helpers when Kaminari is available.
+        #
+        # @param base [Class] the model class including the pagination helpers
         def self.included(base)
           base.instance_eval do
             include Kaminari::ConfigurationMethods

--- a/lib/hawk/model/proxy.rb
+++ b/lib/hawk/model/proxy.rb
@@ -2,64 +2,144 @@
 
 module Hawk
   module Model
+    ##
+    # A proxy object that lazily loads and chains query parameters for
+    # Hawk models. Supports ActiveRecord-like query methods and provides
+    # an Enumerable interface for iterating over results.
+    #
+    # @example Chaining queries
+    #   posts = Post.where(published: true).order(:created_at).limit(10)
+    #   posts.each { |post| puts post.title }
+    #
+    # @example Using as an Enumerable
+    #   post_titles = Post.where(published: true).map(&:title)
+    #
     class Proxy
       include Enumerable
 
+      ##
+      # Initializes a new proxy for the given class with the given params.
+      #
+      # @param klass [Class] the model class
+      # @param params [Hash] query parameters
       def initialize(klass, params)
         @klass   = klass
         @params  = params
         @result  = nil
       end
 
+      ##
+      # A void proxy that returns empty results without making any HTTP requests.
+      #
+      # @example
+      #   Post.none # => Proxy::Void
+      #   Post.none.to_a # => []
       class Void < self
+        ##
+        # @param klass [Class] the model class
+        # @param params [Hash] query parameters
         def initialize(klass, params)
           super
           @params[:void] = true # Only for reporting purposes
           @result = []
         end
 
+        ##
+        # Always returns nil for void proxies.
+        #
+        # @return [nil]
         def find(*)
           nil
         end
 
+        ##
+        # Always returns 0 for void proxies.
+        #
+        # @return [Integer] always 0
         def count(*)
           0
         end
       end
 
+      ##
+      # Returns the model class for this proxy.
+      #
+      # @return [Class] the model class
       attr_reader :klass, :params
 
+      ##
+      # Returns a new proxy with the given params merged.
+      #
+      # @param params [Hash] query parameters to merge
+      # @return [Proxy] a new proxy with merged params
+      #
+      # @example
+      #   posts = Post.where(published: true).where(author: 'John')
       def where(params)
         self.class.new klass, @params.deep_merge(params)
       end
 
+      ##
+      # Finds a record or multiple records by ID(s).
+      #
+      # @param id_or_ids [Integer, Array<Integer>] one or more record IDs
+      # @param params [Hash] additional query parameters
+      # @return [Base, Collection, nil] the found record(s)
       def find(id_or_ids, params = {})
         @result = klass.find(id_or_ids, @params.deep_merge(params))
       end
 
+      ##
+      # Returns all records matching the current query parameters.
+      #
+      # @param params [Hash] additional query parameters
+      # @return [Collection] all matching records
       def all(params = {})
         @result ||= klass.all(@params.deep_merge(params))
       end
       alias result all
 
+      ##
+      # Returns the first record matching the current query parameters.
+      #
+      # @param params [Hash] additional query parameters
+      # @return [Base, nil] the first record, or nil if not found
       def first(params = {})
         limit(1).all(params).first
       end
       alias find_by first
 
+      ##
+      # Returns the first record or raises NotFound.
+      #
+      # @param params [Hash] additional query parameters
+      # @return [Base] the first record
+      # @raise [Hawk::Error::NotFound] if no record is found
       def first!(params = {})
         first(params) or raise Hawk::Error::NotFound, "Can't find #{klass} with #{params.to_json}"
       end
       alias find_by! first!
 
+      ##
+      # Returns the limit value from the query parameters.
+      #
+      # @return [Integer] the limit value
       def limit_value
         params[klass.limit_param].to_i
       end
 
+      ##
+      # Returns the offset value from the query parameters.
+      #
+      # @return [Integer] the offset value
       def offset_value
         params[klass.offset_param].to_i
       end
 
+      ##
+      # Returns the count of matching records.
+      #
+      # @return [Integer] the record count
       def count(*)
         if @result
           @result.count
@@ -68,10 +148,20 @@ module Hawk
         end
       end
 
+      ##
+      # Iterates over all matching records.
+      #
+      # @yield [record] each matching record
       def each(*args, &block)
         all.each(*args, &block)
       end
 
+      ##
+      # Checks if the proxy responds to the given method.
+      #
+      # @param meth [Symbol] the method name
+      # @param include_all [Boolean] whether to include private methods
+      # @return [Boolean] true if the proxy responds to the method
       def respond_to?(meth, include_all = false)
         super ||
           klass.respond_to?(meth, include_all) ||
@@ -80,6 +170,13 @@ module Hawk
 
       protected
 
+      ##
+      # Delegates unknown methods to the model class or result.
+      #
+      # @param meth [Symbol] the method name
+      # @param args [Array] method arguments
+      # @param block [Proc] optional block
+      # @return [Object] the method result
       def method_missing(meth, *args, &block)
         if klass.respond_to?(meth)
 
@@ -118,11 +215,20 @@ module Hawk
 
       private
 
+      ##
+      # Merges another proxy's parameters into this one.
+      #
+      # @param other [Proxy] the other proxy to merge
+      # @return [Proxy] this proxy with merged parameters
       def merge(other)
         target = other.is_a?(Void) ? to_void : self
         target.where(other.params)
       end
 
+      ##
+      # Converts this proxy to a void proxy.
+      #
+      # @return [Void] a void proxy with the same parameters
       def to_void
         Void.new(klass, params)
       end

--- a/lib/hawk/model/querying.rb
+++ b/lib/hawk/model/querying.rb
@@ -2,81 +2,195 @@
 
 module Hawk
   module Model
+    ##
+    # Provides ActiveRecord-like querying methods for Hawk models.
+    # Supports chaining methods like `where`, `limit`, `offset`, `order`,
+    # and `includes` through a Proxy object.
+    #
+    # @example Chaining queries
+    #   posts = Post.where(published: true).order(:created_at).limit(10)
+    #
+    # @example Using scopes
+    #   class Post < Hawk::Model::Base
+    #     scope :published, -> { where(published: true) }
+    #     scope :recent, -> { order(:created_at).limit(10) }
+    #   end
+    #
+    #   posts = Post.published.recent
+    #
     module Querying
+      ##
+      # Extends the including model with class-level query builders.
+      #
+      # @param base [Class] the model class including the querying helpers
       def self.included(base)
         base.extend ClassMethods
       end
 
+      ##
+      # Class-level query helper methods that return Proxy instances.
       module ClassMethods
-        # Returns an empty +Proxy+
+        ##
+        # Returns an empty proxy that will not fetch any records.
         #
+        # @return [Proxy::Void] an empty proxy
+        #
+        # @example
+        #   Post.none # => []
         def none
           Proxy::Void.new(self, {})
         end
 
-        # Returns a +Proxy+ with the given params
+        ##
+        # Returns a proxy with the given query parameters.
         #
+        # @param params [Hash] query parameters
+        # @return [Proxy] a new proxy with the given params
+        #
+        # @example
+        #   posts = Post.where(published: true)
+        #   posts.all # => [...]
         def where(params)
           Proxy.new(self, params)
         end
 
-        # Returns a +Proxy+ with the default params
+        ##
+        # Returns a proxy with the default params merged with the given params.
         #
+        # @param params [Hash] additional query parameters
+        # @return [Proxy] a new proxy
         def scoped(params = {})
           where(default_params.deep_merge(params))
         end
 
+        ##
+        # Returns all records, merging default params with the given params.
+        #
+        # @param params [Hash] additional query parameters
+        # @return [Collection] all matching records
         def all(params = {})
           super(default_params.deep_merge(params))
         end
 
+        ##
+        # Sets or returns the default params for this model class.
+        #
+        # @param params [Hash, nil] default params to set
+        # @return [Hash] the default params
         def default_params(params = nil)
           @default_params = params if params
           @default_params ||= {}
         end
 
-        # Adds +limit+ with the given number of records
+        ##
+        # Returns a proxy with the given limit.
         #
+        # @param value [Integer] the maximum number of records to return
+        # @return [Proxy] a new proxy with the limit
+        #
+        # @example
+        #   posts = Post.limit(10)
         def limit(value)
           where(limit_param => value)
         end
 
-        # Adds an +offset+ with the given number of records
+        ##
+        # Returns a proxy with the given offset.
         #
+        # @param value [Integer] the number of records to skip
+        # @return [Proxy] a new proxy with the offset
+        #
+        # @example
+        #   posts = Post.offset(20)
         def offset(value)
           where(offset_param => value)
         end
 
+        ##
+        # Returns a proxy with the given order.
+        #
+        # @param by [String, Symbol] the column to order by
+        # @return [Proxy] a new proxy with the order
+        #
+        # @example
+        #   posts = Post.order(:created_at)
         def order(by)
           where(order: by)
         end
 
+        ##
+        # Returns a proxy that includes the specified associations.
+        #
+        # @param what [String, Symbol, Array] the associations to include
+        # @return [Proxy] a new proxy with includes
+        #
+        # @example
+        #   posts = Post.includes(:comments)
         def includes(what)
           where(includes: what)
         end
 
+        ##
+        # Returns a proxy with the given options.
+        #
+        # @param opts [Hash] additional options
+        # @return [Proxy] a new proxy with the options
+        #
+        # @example
+        #   posts = Post.options(endpoint: 'featured')
         def options(opts)
           where(options: opts)
         end
 
+        ##
+        # Returns a proxy with basic authentication credentials.
+        #
+        # @param username [String] the username
+        # @param password [String] the password
+        # @return [Proxy] a new proxy with auth credentials
+        #
+        # @example
+        #   posts = Post.auth('user', 'pass')
         def auth(username, password)
           options(username: username, password: password)
         end
 
+        ##
+        # Returns a proxy with a custom endpoint.
+        #
+        # @param path [String] the endpoint path
+        # @return [Proxy] a new proxy with the endpoint
+        #
+        # @example
+        #   posts = Post.from('featured')
         def from(path)
           options(endpoint: path)
         end
 
-        # Adds a limit(1) and returns the first record
+        ##
+        # Returns the first record with a limit of 1.
         #
+        # @param params [Hash] additional query parameters
+        # @return [Base, nil] the first record, or nil if not found
+        #
+        # @example
+        #   post = Post.first
+        #   post = Post.find_by(published: true)
         def first(params = {})
           limit(1).first(params)
         end
         alias find_by first
 
-        # Looks for the first record or raises a
-        # {Hawk::Error::NotFound} if not found
+        ##
+        # Returns the first record or raises NotFound if not found.
         #
+        # @param params [Hash] additional query parameters
+        # @return [Base] the first record
+        # @raise [Hawk::Error::NotFound] if no record is found
+        #
+        # @example
+        #   post = Post.first!
+        #   post = Post.find_by!(published: true)
         def first!(params = {})
           first(params) or raise(Hawk::Error::NotFound, "Can't find first #{self}")
         end

--- a/lib/hawk/model/schema.rb
+++ b/lib/hawk/model/schema.rb
@@ -2,16 +2,59 @@
 
 module Hawk
   module Model
+    ##
+    # Provides schema definition and attribute casting for Hawk models.
+    # Automatically infers data types from attribute names and provides
+    # type casting for common patterns like dates, booleans, and numbers.
+    #
+    # @example Defining a schema
+    #   class Post < Hawk::Model::Base
+    #     schema do
+    #       integer :id
+    #       string :title, :body
+    #       datetime :created_at
+    #       boolean :published
+    #     end
+    #   end
+    #
+    # @example Automatic type casting
+    #   # Attributes ending in _at, _from, _until, _on are cast to DateTime
+    #   # Attributes ending in _date are cast to Date
+    #   # Attributes ending in _num are cast to BigDecimal
+    #   # Attributes starting with is_ are cast to Boolean
+    #   class Event < Hawk::Model::Base
+    #     schema do
+    #       string :name
+    #     end
+    #   end
+    #
+    #   # created_at will be automatically cast to DateTime
+    #   event = Event.new(created_at: "2024-01-15T10:30:00Z")
+    #   event.created_at.class # => Time
+    #
     module Schema
+      ##
+      # Extends the including model with class-level schema definition helpers.
+      #
+      # @param base [Class] the model class including the schema helpers
       def self.included(base)
         base.extend ClassMethods
       end
 
+      ##
+      # Initializes the model with the given attributes, casting values
+      # according to the schema definition.
+      #
+      # @param attributes [Hash] attribute key-value pairs
       def initialize(attributes = {}, _params = {})
         cast!(attributes)
         # super not required, this is the last in the chain.
       end
 
+      ##
+      # Returns a hash of all attributes and their current values.
+      #
+      # @return [Hash] attribute key-value pairs
       def attributes
         schema.each_key.inject({}) do |ret, key|
           ret.update(key => read_attribute(key))
@@ -19,28 +62,56 @@ module Hawk
       end
       alias to_h attributes
 
+      ##
+      # Returns the attributes hash for JSON serialization.
+      #
+      # @return [Hash] attribute key-value pairs
       def as_json(*_ignored) # FIXME
         to_h
       end
 
+      ##
+      # Reads the value of an attribute by name.
+      #
+      # @param name [String, Symbol] the attribute name
+      # @return [Object] the attribute value
       def read_attribute(name)
         get_attribute(name)
       end
 
+      ##
+      # Writes a value to an attribute by name.
+      #
+      # @param name [String, Symbol] the attribute name
+      # @param value [Object] the value to set
       def write_attribute(name, value)
         set_attribute(name, value)
       end
 
       private
 
+      ##
+      # Gets an attribute value from the instance variable.
+      #
+      # @param name [String] the attribute name
+      # @return [Object] the attribute value
       def get_attribute(name)
         instance_variable_get(['@', name].join)
       end
 
+      ##
+      # Sets an attribute value in the instance variable.
+      #
+      # @param name [String] the attribute name
+      # @param value [Object] the value to set
       def set_attribute(name, value)
         instance_variable_set(['@', name].join, value)
       end
 
+      ##
+      # Casts all attributes according to the schema definition.
+      #
+      # @param attributes [Hash] attribute key-value pairs
       def cast!(attributes)
         schema(attributes).each do |key, caster|
           next unless attributes.key?(key)
@@ -52,6 +123,11 @@ module Hawk
         end
       end
 
+      ##
+      # Returns the schema definition for this model.
+      #
+      # @param attributes [Hash, nil] optional attributes to define schema from
+      # @return [Hash] schema definition mapping attribute names to casters
       def schema(attributes = nil)
         if attributes.present? && self.class.schema.nil?
           self.class.define_schema_from(attributes)
@@ -61,19 +137,40 @@ module Hawk
 
       autoload :DSL, 'hawk/model/schema/dsl'
 
+      ##
+      # Class-level schema definition and inference helpers.
       module ClassMethods
+        ##
+        # Inherits schema definition from parent class.
         def inherited(subclass)
           super
           subclass.instance_variable_set :@_schema,       schema       if schema
           subclass.instance_variable_set :@_after_schema, after_schema if after_schema
         end
 
+        ##
+        # Defines or returns the schema for this model.
+        #
+        # @yield [dsl] block to define schema using DSL methods
+        # @return [Hash, nil] the schema definition
+        #
+        # @example Defining a schema
+        #   class Post < Hawk::Model::Base
+        #     schema do
+        #       integer :id
+        #       string :title
+        #     end
+        #   end
         def schema(&block)
           define_schema_via_dsl(&block) if block
 
           @_schema
         end
 
+        ##
+        # Defines the schema using the DSL.
+        #
+        # @param code [Proc] block containing schema definition
         def define_schema_via_dsl(&code)
           @_schema = {}
 
@@ -84,6 +181,10 @@ module Hawk
           end
         end
 
+        ##
+        # Defines schema from a hash of attributes (used for automatic schema inference).
+        #
+        # @param attributes [Hash] attribute names to infer schema from
         def define_schema_from(attributes)
           @_schema = {}
 
@@ -96,6 +197,12 @@ module Hawk
           end
         end
 
+        ##
+        # Defines a single schema key with its caster, generating getter, setter,
+        # and optionally a predicate method for booleans.
+        #
+        # @param key [String] the attribute name
+        # @param caster [Caster, nil] the type caster
         def define_schema_key(key, caster)
           return if association?(key)
 
@@ -114,6 +221,11 @@ module Hawk
           end
         end
 
+        ##
+        # Returns the schema type for a given attribute.
+        #
+        # @param attribute_name [String, Symbol] the attribute name
+        # @return [Symbol] the attribute type
         def schema_type_of(attribute_name)
           if (caster = find_schema_caster_for(attribute_name))
             caster.type
@@ -122,6 +234,11 @@ module Hawk
           end
         end
 
+        ##
+        # Finds the appropriate caster for an attribute based on its name.
+        #
+        # @param attribute [String] the attribute name
+        # @return [Caster, nil] the caster for this attribute
         def find_schema_caster_for(attribute)
           ATTRIBUTE_CASTS.each do |re, type|
             if attribute&.match?(re)
@@ -132,29 +249,56 @@ module Hawk
           nil
         end
 
+        ##
+        # Returns the caster for a given type.
+        #
+        # @param type [Symbol] the type name
+        # @return [Caster, nil] the caster for this type
         def find_schema_caster_typed(type)
           CASTERS.fetch(type, nil)
         end
 
+        ##
+        # Defines a callback to be executed after schema is defined.
+        #
+        # @yield block to execute after schema definition
         def after_schema(&block)
           @_after_schema = block if block
           @_after_schema
         end
       end
 
+      ##
+      # Represents a type caster that converts values to a specific type.
+      #
+      # @attr_reader type [Symbol] the type this caster converts to
       class Caster
+        ##
+        # Initializes a new caster with the given type and conversion code.
+        #
+        # @param type [Symbol] the type name
+        # @param code [Proc] the conversion lambda
         def initialize(type, code)
           @type = type
           @code = code
         end
         attr_reader :type
 
+        ##
+        # Casts a value to this caster's type.
+        #
+        # @param value [Object] the value to cast
+        # @return [Object, String, nil] the cast value; nil if input is nil; an error message String if casting raises
         def call(value)
           @code.call(value) unless value.nil?
         rescue StandardError => e
           "## Error while casting #{value} to #{type}: #{e.message} ##"
         end
 
+        ##
+        # Returns a string representation of the caster.
+        #
+        # @return [String] human-readable representation
         def to_s
           src, line = @code.source_location
           "#<Cast to #{type} using #{File.basename(src)}:#{line})>"
@@ -163,9 +307,13 @@ module Hawk
         alias pretty_inspect to_s
       end
 
+      ##
+      # Boolean values that are considered truthy.
       BOOLS = Set.new(['1', 'true', 1, true]).freeze
       private_constant :BOOLS
 
+      ##
+      # Built-in type casters.
       CASTERS = [
         Caster.new(:integer,  ->(value) { Integer(value) }),
         Caster.new(:float,    ->(value) { Float(value) }),
@@ -176,6 +324,8 @@ module Hawk
       ].inject({}) { |h, c| h.update(c.type => c) }
       private_constant :CASTERS
 
+      ##
+      # Patterns for automatic type inference from attribute names.
       ATTRIBUTE_CASTS = {
         /_(?:at|from|until|on)$/ => :datetime,
         /_date$/ => :date,

--- a/lib/hawk/model/schema/dsl.rb
+++ b/lib/hawk/model/schema/dsl.rb
@@ -3,21 +3,51 @@
 module Hawk
   module Model
     module Schema
+      ##
+      # A DSL for defining schema types in a declarative way.
+      # Used internally by the Schema module to parse schema definitions.
+      #
+      # @example Using the DSL
+      #   DSL.eval do
+      #     integer :id
+      #     string :title, :body
+      #     datetime :created_at
+      #     boolean :published
+      #   end
+      #
       class DSL
+        ##
+        # Evaluates a DSL block and yields the resulting type-attributes pairs.
+        #
+        # @param code [Proc] the DSL block
+        # @yield [type, attributes] each type and its attributes
         def self.eval(code, &block)
           new(code).each(&block)
         end
 
+        ##
+        # Initializes the DSL with the given code block.
+        #
+        # @param code [Proc] the DSL block to evaluate
         def initialize(code)
           @types = Hash.new { |h, k| h[k] = [] }
 
           instance_eval(&code)
         end
 
+        ##
+        # Iterates over each type-attributes pair.
+        #
+        # @yield [type, attributes] each type and its attributes
         def each(&block)
           @types.each(&block)
         end
 
+        ##
+        # Handles unknown methods by treating them as type definitions.
+        #
+        # @param meth [Symbol] the type name (e.g., :integer, :string)
+        # @param args [Array] the attribute names
         def method_missing(meth, *args)
           @types[meth] += args
         end

--- a/lib/hawk/model/scoping.rb
+++ b/lib/hawk/model/scoping.rb
@@ -2,12 +2,48 @@
 
 module Hawk
   module Model
+    ##
+    # Provides ActiveRecord-like scope methods for Hawk models.
+    # Scopes are class-level methods that return a Proxy with predefined
+    # query parameters.
+    #
+    # @example Defining scopes
+    #   class Post < Hawk::Model::Base
+    #     scope :published, -> { where(published: true) }
+    #     scope :recent, -> { order(:created_at).limit(10) }
+    #     scope :by_author, ->(name) { where(author: name) }
+    #   end
+    #
+    # @example Using scopes
+    #   Post.published # => Proxy with published: true
+    #   Post.recent.order(:title) # => Chain scopes
+    #   Post.by_author('John').limit(5) # => Parameters work too
+    #
     module Scoping
+      ##
+      # Extends the including model with named scope definitions.
+      #
+      # @param base [Class] the model class including the scoping helpers
       def self.included(base)
         base.extend ClassMethods
       end
 
+      ##
+      # Class-level scope declaration helpers.
       module ClassMethods
+        ##
+        # Defines a named scope on the model class.
+        #
+        # @param name [Symbol] the scope name
+        # @param impl [Proc] the scope implementation (should return a Proxy)
+        # @raise [Hawk::Error::Configuration] if a method with this name already exists
+        #
+        # @example
+        #   class Post < Hawk::Model::Base
+        #     scope :published, -> { where(published: true) }
+        #   end
+        #
+        #   Post.published.all # => [...]
         def scope(name, impl)
           if respond_to?(name)
             raise Error::Configuration, "#{self.name} already has a #{name} singleton method defined"

--- a/lib/hawk/version.rb
+++ b/lib/hawk/version.rb
@@ -1,5 +1,12 @@
 # frozen_string_literal: true
 
+# The Hawk module serves as a namespace for the Hawk library.
+# It encapsulates all the functionality and components of the library,
+# ensuring that classes, modules, and constants are organized and do not
+# conflict with other parts of the application or other libraries.
 module Hawk
+  # Defines the current version of the Hawk library.
+  # It follows semantic versioning (MAJOR.MINOR.PATCH) to indicate
+  # the release version of the library.
   VERSION = '4.0.0'
 end


### PR DESCRIPTION
- Add YARD documentation to all lib files (hawk.rb, model.rb, http.rb, etc.)
- Document all public methods with @param, @return, @raise, @example tags
- Fill README Usage section with examples for:
  - Defining models with schema
  - Finding records (find, find!, first, first!, all)
  - Querying (where, limit, offset, order, includes)
  - Defining and using scopes
  - Associations (has_many, has_one, belongs_to, polymorphic)
  - Caching configuration
  - Error handling
  - Persisting records with ActiveModel
  - Instrumentation

Closes #7